### PR TITLE
Add learning materials for 11 languages

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,8 +119,9 @@ def mode_selection(lang_code):
         flash(get_text("flash_language_load_error"), "error")
         return redirect(url_for("index"))
 
-    # Currently only Spanish has learning materials
-    has_learn_materials = lang_code == "es"
+    has_learn_materials = lang_code in {
+        "es", "fr", "ja", "de", "ko", "it", "zh", "pt", "tr", "sv", "da", "no",
+    }
 
     return render_template(
         "index.html",
@@ -563,7 +564,9 @@ def results(lang_code):
     show_splash = session.pop("show_speed_splash", False)
     show_perfect_splash = session.pop("show_perfect_splash", False)
 
-    has_learn_materials = lang_code == "es"
+    has_learn_materials = lang_code in {
+        "es", "fr", "ja", "de", "ko", "it", "zh", "pt", "tr", "sv", "da", "no",
+    }
 
     return render_template(
         "results.html",
@@ -615,8 +618,9 @@ def learn(lang_code):
     if not is_language_ready(lang_code):
         return redirect(url_for("index"))
 
-    # Currently only Spanish has learn pages
-    if lang_code != "es":
+    if lang_code not in {
+        "es", "fr", "ja", "de", "ko", "it", "zh", "pt", "tr", "sv", "da", "no",
+    }:
         flash(get_text("flash_learn_not_available"), "info")
         return redirect(url_for("mode_selection", lang_code=lang_code))
 
@@ -659,7 +663,8 @@ def sitemap_xml():
     for lang_code, lang_info in AVAILABLE_LANGUAGES.items():
         if lang_info.get("ready"):
             urls.append((f"{base}/{lang_code}", "0.8"))
-    urls.append((f"{base}/es/learn", "0.7"))
+    for lc in ["es", "fr", "ja", "de", "ko", "it", "zh", "pt", "tr", "sv", "da", "no"]:
+        urls.append((f"{base}/{lc}/learn", "0.7"))
     urls.append((f"{base}/about", "0.5"))
     urls.append((f"{base}/privacy", "0.3"))
     urls.append((f"{base}/imprint", "0.3"))

--- a/templates/learn_da_de.html
+++ b/templates/learn_da_de.html
@@ -1,0 +1,140 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>D&auml;nische Zahlen lernen</h1>
+      <p>
+        Diese Seite erkl&auml;rt <strong>d&auml;nische Zahlw&ouml;rter</strong>. D&auml;nisch ist bekannt f&uuml;r sein <strong>Vigesimalsystem</strong> (Basis 20)
+        bei den Zehnern &mdash; 50 bedeutet w&ouml;rtlich &bdquo;halb-drittel-mal-zwanzig&ldquo; (<em>halvtreds</em>).
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;12: unregelm&auml;&szlig;ige Grundzahlen</a></li>
+        <li><a href="#teens">13&ndash;19: Teens</a></li>
+        <li><a href="#tens">20&ndash;99: Vigesimale Zehner</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender &amp; gro&szlig;e Zahlen</a></li>
+        <li><a href="#mistakes">Typische Fehler</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;12: unregelm&auml;&szlig;ige Grundzahlen</h2>
+      <p>Einzeln auswendig lernen:</p>
+      <ul>
+        <li><strong>0</strong> = nul</li>
+        <li><strong>1</strong> = en / et</li>
+        <li><strong>2</strong> = to</li>
+        <li><strong>3</strong> = tre</li>
+        <li><strong>4</strong> = fire</li>
+        <li><strong>5</strong> = fem</li>
+        <li><strong>6</strong> = seks</li>
+        <li><strong>7</strong> = syv</li>
+        <li><strong>8</strong> = otte</li>
+        <li><strong>9</strong> = ni</li>
+        <li><strong>10</strong> = ti</li>
+        <li><strong>11</strong> = elleve</li>
+        <li><strong>12</strong> = tolv</li>
+      </ul>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>13&ndash;19: Teens</h2>
+      <p>
+        Muster: Ziffer + <strong>ten</strong> (von &bdquo;ti&ldquo;):
+      </p>
+      <ul>
+        <li><strong>13</strong> = tretten</li>
+        <li><strong>14</strong> = fjorten</li>
+        <li><strong>15</strong> = femten</li>
+        <li><strong>16</strong> = seksten</li>
+        <li><strong>17</strong> = sytten</li>
+        <li><strong>18</strong> = atten</li>
+        <li><strong>19</strong> = nitten</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: Vigesimale Zehner</h2>
+      <p>
+        D&auml;nisch verwendet ein <strong>Zwanzigersystem</strong> f&uuml;r die Zehner. 20 und 30 sind einfach, aber 50, 60, 70, 80, 90 basieren auf
+        Vielfachen von 20:
+      </p>
+      <ul>
+        <li><strong>20</strong> = tyve</li>
+        <li><strong>30</strong> = tredive</li>
+        <li><strong>40</strong> = fyrre (Kurzform von &bdquo;fire gange ti&ldquo; = 4&times;10)</li>
+        <li><strong>50</strong> = halvtreds (halb-drittel-mal-zwanzig = 2,5&times;20)</li>
+        <li><strong>60</strong> = tres (drei-mal-zwanzig = 3&times;20)</li>
+        <li><strong>70</strong> = halvfjerds (halb-viertel-mal-zwanzig = 3,5&times;20)</li>
+        <li><strong>80</strong> = firs (vier-mal-zwanzig = 4&times;20)</li>
+        <li><strong>90</strong> = halvfems (halb-f&uuml;nftel-mal-zwanzig = 4,5&times;20)</li>
+      </ul>
+      <p>
+        Einer kommen <strong>vor</strong> den Zehnern, verbunden mit <strong>og</strong> (&bdquo;und&ldquo;):
+      </p>
+      <ul>
+        <li><strong>21</strong> = enogtyve</li>
+        <li><strong>53</strong> = treoghalvtreds</li>
+        <li><strong>99</strong> = nioghalvfems</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 25, 50, 74?</summary>
+        <p><strong>25</strong> femogtyve &middot; <strong>50</strong> halvtreds &middot; <strong>74</strong> fireoghalvfjerds</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <ul>
+        <li><strong>100</strong> = (et) hundrede</li>
+        <li><strong>200</strong> = to hundrede</li>
+        <li><strong>300</strong> = tre hundrede</li>
+        <li><strong>150</strong> = (et) hundrede og halvtreds</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender &amp; gro&szlig;e Zahlen</h2>
+      <ul>
+        <li><strong>1.000</strong> = (et) tusind(e)</li>
+        <li><strong>2.000</strong> = to tusind(e)</li>
+        <li><strong>10.000</strong> = ti tusind(e)</li>
+        <li><strong>1.000.000</strong> = en million</li>
+        <li><strong>1.000.000.000</strong> = en milliard</li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Typische Fehler</h2>
+      <ol>
+        <li><strong>Vigesimale Zehner</strong>: halvtreds (50), tres (60), halvfjerds (70), firs (80), halvfems (90) &mdash; m&uuml;ssen auswendig gelernt werden.</li>
+        <li><strong>Reihenfolge</strong>: Einer vor Zehnern (enogtyve = 21), wie im Deutschen.</li>
+        <li><strong>og</strong>: die Konjunktion zwischen Einern und Zehnern nicht vergessen.</li>
+        <li><strong>en vs. et</strong>: &bdquo;en&ldquo; f&uuml;r Utrum, &bdquo;et&ldquo; f&uuml;r Neutrum.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_da_en.html
+++ b/templates/learn_da_en.html
@@ -1,0 +1,140 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn Danish Numbers</h1>
+      <p>
+        This page covers <strong>Danish number words</strong>. Danish is famous for its <strong>vigesimal</strong> (base-20) system
+        for tens &mdash; 50 is literally &ldquo;half-third-times-twenty&rdquo; (<em>halvtreds</em>). Once you understand the pattern, it&rsquo;s consistent.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;12: irregular bases</a></li>
+        <li><a href="#teens">13&ndash;19: teens</a></li>
+        <li><a href="#tens">20&ndash;99: vigesimal tens</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands &amp; large numbers</a></li>
+        <li><a href="#mistakes">Common mistakes</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;12: irregular bases</h2>
+      <p>Memorize these individually:</p>
+      <ul>
+        <li><strong>0</strong> = nul</li>
+        <li><strong>1</strong> = en / et</li>
+        <li><strong>2</strong> = to</li>
+        <li><strong>3</strong> = tre</li>
+        <li><strong>4</strong> = fire</li>
+        <li><strong>5</strong> = fem</li>
+        <li><strong>6</strong> = seks</li>
+        <li><strong>7</strong> = syv</li>
+        <li><strong>8</strong> = otte</li>
+        <li><strong>9</strong> = ni</li>
+        <li><strong>10</strong> = ti</li>
+        <li><strong>11</strong> = elleve</li>
+        <li><strong>12</strong> = tolv</li>
+      </ul>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>13&ndash;19: teens</h2>
+      <p>
+        Pattern: digit + <strong>ten</strong> (from &ldquo;ti&rdquo;):
+      </p>
+      <ul>
+        <li><strong>13</strong> = tretten</li>
+        <li><strong>14</strong> = fjorten</li>
+        <li><strong>15</strong> = femten</li>
+        <li><strong>16</strong> = seksten</li>
+        <li><strong>17</strong> = sytten</li>
+        <li><strong>18</strong> = atten</li>
+        <li><strong>19</strong> = nitten</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: vigesimal tens</h2>
+      <p>
+        Danish uses a <strong>base-20</strong> system for its tens. 20 and 30 are straightforward, but 50, 60, 70, 80, 90 are based on
+        multiples of 20:
+      </p>
+      <ul>
+        <li><strong>20</strong> = tyve</li>
+        <li><strong>30</strong> = tredive</li>
+        <li><strong>40</strong> = fyrre (short for &ldquo;fire gange ti&rdquo; = 4&times;10)</li>
+        <li><strong>50</strong> = halvtreds (half-third-times-twenty = 2.5&times;20)</li>
+        <li><strong>60</strong> = tres (three-times-twenty = 3&times;20)</li>
+        <li><strong>70</strong> = halvfjerds (half-fourth-times-twenty = 3.5&times;20)</li>
+        <li><strong>80</strong> = firs (four-times-twenty = 4&times;20)</li>
+        <li><strong>90</strong> = halvfems (half-fifth-times-twenty = 4.5&times;20)</li>
+      </ul>
+      <p>
+        Ones come <strong>before</strong> tens, connected with <strong>og</strong> (&ldquo;and&rdquo;):
+      </p>
+      <ul>
+        <li><strong>21</strong> = enogtyve</li>
+        <li><strong>53</strong> = treoghalvtreds</li>
+        <li><strong>99</strong> = nioghalvfems</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 25, 50, 74?</summary>
+        <p><strong>25</strong> femogtyve &middot; <strong>50</strong> halvtreds &middot; <strong>74</strong> fireoghalvfjerds</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <ul>
+        <li><strong>100</strong> = (et) hundrede</li>
+        <li><strong>200</strong> = to hundrede</li>
+        <li><strong>300</strong> = tre hundrede</li>
+        <li><strong>150</strong> = (et) hundrede og halvtreds</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands &amp; large numbers</h2>
+      <ul>
+        <li><strong>1,000</strong> = (et) tusind(e)</li>
+        <li><strong>2,000</strong> = to tusind(e)</li>
+        <li><strong>10,000</strong> = ti tusind(e)</li>
+        <li><strong>1,000,000</strong> = en million</li>
+        <li><strong>1,000,000,000</strong> = en milliard</li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Common mistakes</h2>
+      <ol>
+        <li><strong>Vigesimal tens</strong>: halvtreds (50), tres (60), halvfjerds (70), firs (80), halvfems (90) &mdash; these must be memorized.</li>
+        <li><strong>Word order</strong>: ones before tens (enogtyve = 21), like German.</li>
+        <li><strong>og</strong>: don&rsquo;t forget the conjunction between ones and tens.</li>
+        <li><strong>en vs. et</strong>: &ldquo;en&rdquo; for common gender, &ldquo;et&rdquo; for neuter.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_de_de.html
+++ b/templates/learn_de_de.html
@@ -1,0 +1,151 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>Deutsche Zahlen lernen</h1>
+      <p>
+        Diese Seite erkl&auml;rt <strong>deutsche Zahlw&ouml;rter</strong> &mdash; zusammengesetzte W&ouml;rter, umgekehrte Reihenfolge
+        (Einer vor Zehnern), Umlaute und Sonderformen wie <em>eins</em> vs. <em>ein</em>.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;12: unregelm&auml;&szlig;ige Grundzahlen</a></li>
+        <li><a href="#teens">13&ndash;19: Teens</a></li>
+        <li><a href="#tens">20&ndash;99: umgekehrte Reihenfolge</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender &amp; gro&szlig;e Zahlen</a></li>
+        <li><a href="#spelling">Zusammengesetzte W&ouml;rter &amp; Umlaute</a></li>
+        <li><a href="#mistakes">Typische Fehler</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;12: unregelm&auml;&szlig;ige Grundzahlen</h2>
+      <p>Diese W&ouml;rter einfach auswendig lernen:</p>
+      <ul>
+        <li><strong>0</strong> = null</li>
+        <li><strong>1</strong> = eins</li>
+        <li><strong>2</strong> = zwei</li>
+        <li><strong>3</strong> = drei</li>
+        <li><strong>4</strong> = vier</li>
+        <li><strong>5</strong> = f&uuml;nf</li>
+        <li><strong>6</strong> = sechs</li>
+        <li><strong>7</strong> = sieben</li>
+        <li><strong>8</strong> = acht</li>
+        <li><strong>9</strong> = neun</li>
+        <li><strong>10</strong> = zehn</li>
+        <li><strong>11</strong> = elf</li>
+        <li><strong>12</strong> = zw&ouml;lf</li>
+      </ul>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>13&ndash;19: Teens</h2>
+      <p>
+        Muster: Ziffer + <strong>zehn</strong>:
+      </p>
+      <ul>
+        <li><strong>13</strong> = dreizehn</li>
+        <li><strong>14</strong> = vierzehn</li>
+        <li><strong>16</strong> = sechzehn (nicht &bdquo;sechszehn&ldquo;)</li>
+        <li><strong>17</strong> = siebzehn (nicht &bdquo;siebenzehn&ldquo;)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: umgekehrte Reihenfolge</h2>
+      <p>
+        Im Deutschen kommt der <strong>Einer zuerst</strong>, dann <strong>und</strong>, dann der Zehner &mdash;
+        alles als <strong>ein zusammengesetztes Wort</strong>:
+      </p>
+      <ul>
+        <li><strong>21</strong> = einundzwanzig (ein-und-zwanzig)</li>
+        <li><strong>34</strong> = vierunddrei&szlig;ig</li>
+        <li><strong>57</strong> = siebenundf&uuml;nfzig</li>
+        <li><strong>99</strong> = neunundneunzig</li>
+      </ul>
+      <p>
+        Die Zehnerw&ouml;rter: zwanzig (20), drei&szlig;ig (30), vierzig (40), f&uuml;nfzig (50), sechzig (60),
+        siebzig (70), achtzig (80), neunzig (90).
+      </p>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 23, 45, 88?</summary>
+        <p><strong>23</strong> dreiundzwanzig &middot; <strong>45</strong> f&uuml;nfundvierzig &middot; <strong>88</strong> achtundachtzig</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <ul>
+        <li><strong>100</strong> = (ein)hundert</li>
+        <li><strong>200</strong> = zweihundert</li>
+        <li><strong>300</strong> = dreihundert</li>
+        <li><strong>123</strong> = (ein)hundertdreiundzwanzig</li>
+      </ul>
+      <p>
+        Alles wird als ein langes zusammengesetztes Wort ohne Leerzeichen geschrieben.
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender &amp; gro&szlig;e Zahlen</h2>
+      <ul>
+        <li><strong>1.000</strong> = (ein)tausend</li>
+        <li><strong>2.000</strong> = zweitausend</li>
+        <li><strong>10.000</strong> = zehntausend</li>
+        <li><strong>1.000.000</strong> = eine Million</li>
+        <li><strong>1.000.000.000</strong> = eine Milliarde</li>
+      </ul>
+      <p>
+        Zahlen bis 999.999 sind ein zusammengesetztes Wort. <strong>Million</strong> und <strong>Milliarde</strong>
+        sind eigenst&auml;ndige Substantive.
+      </p>
+    </section>
+
+    <section id="spelling" class="learn-section">
+      <h2>Zusammengesetzte W&ouml;rter &amp; Umlaute</h2>
+      <p>
+        Wichtige Details zur Schreibweise:
+      </p>
+      <ul>
+        <li>Alle Zahlen unter einer Million werden als <strong>ein Wort</strong> geschrieben (keine Leerzeichen, keine Bindestriche)</li>
+        <li>Umlaute beachten: f<strong>&uuml;</strong>nf, zw<strong>&ouml;</strong>lf, f&uuml;nfzig, drei<strong>&szlig;</strong>ig</li>
+        <li><strong>sechs</strong> verliert das &bdquo;s&ldquo;: sech<em>zehn</em>, sech<em>zig</em></li>
+        <li><strong>sieben</strong> wird zu sieb-: sieb<em>zehn</em>, sieb<em>zig</em></li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Typische Fehler</h2>
+      <ol>
+        <li><strong>Reihenfolge</strong>: 42 ist <em>zwei</em>und<em>vierzig</em>, nicht vierzig-und-zwei.</li>
+        <li><strong>eins vs. ein</strong>: &bdquo;eins&ldquo; steht allein, aber &bdquo;ein&ldquo; in Zusammensetzungen (einundzwanzig, einhundert).</li>
+        <li><strong>drei&szlig;ig</strong>: mit &bdquo;&szlig;&ldquo; (nicht &bdquo;z&ldquo;) &mdash; das einzige Zehnerwort, das nicht auf -zig endet.</li>
+        <li><strong>Leerzeichen</strong>: keine Leerzeichen innerhalb von Zahlen unter einer Million.</li>
+        <li><strong>sechzehn / siebzehn</strong>: verk&uuml;rzte St&auml;mme, nicht &bdquo;sechszehn&ldquo; oder &bdquo;siebenzehn&ldquo;.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_de_en.html
+++ b/templates/learn_de_en.html
@@ -1,0 +1,151 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn German Numbers</h1>
+      <p>
+        This page covers <strong>German number words</strong> &mdash; compound words, reversed word order
+        (ones before tens), umlauts, and special forms like <em>eins</em> vs. <em>ein</em>.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;12: irregular bases</a></li>
+        <li><a href="#teens">13&ndash;19: teens</a></li>
+        <li><a href="#tens">20&ndash;99: reversed order</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands &amp; large numbers</a></li>
+        <li><a href="#spelling">Compound words &amp; umlauts</a></li>
+        <li><a href="#mistakes">Common mistakes</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;12: irregular bases</h2>
+      <p>Memorize these individually:</p>
+      <ul>
+        <li><strong>0</strong> = null</li>
+        <li><strong>1</strong> = eins</li>
+        <li><strong>2</strong> = zwei</li>
+        <li><strong>3</strong> = drei</li>
+        <li><strong>4</strong> = vier</li>
+        <li><strong>5</strong> = f&uuml;nf</li>
+        <li><strong>6</strong> = sechs</li>
+        <li><strong>7</strong> = sieben</li>
+        <li><strong>8</strong> = acht</li>
+        <li><strong>9</strong> = neun</li>
+        <li><strong>10</strong> = zehn</li>
+        <li><strong>11</strong> = elf</li>
+        <li><strong>12</strong> = zw&ouml;lf</li>
+      </ul>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>13&ndash;19: teens</h2>
+      <p>
+        Pattern: digit + <strong>zehn</strong> (like English &ldquo;-teen&rdquo;):
+      </p>
+      <ul>
+        <li><strong>13</strong> = dreizehn</li>
+        <li><strong>14</strong> = vierzehn</li>
+        <li><strong>16</strong> = sechzehn (not &ldquo;sechszehn&rdquo;)</li>
+        <li><strong>17</strong> = siebzehn (not &ldquo;siebenzehn&rdquo;)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: reversed order</h2>
+      <p>
+        German says the <strong>ones digit first</strong>, then <strong>und</strong> (&ldquo;and&rdquo;), then the tens &mdash;
+        all written as <strong>one compound word</strong>:
+      </p>
+      <ul>
+        <li><strong>21</strong> = einundzwanzig (one-and-twenty)</li>
+        <li><strong>34</strong> = vierunddrei&szlig;ig</li>
+        <li><strong>57</strong> = siebenundf&uuml;nfzig</li>
+        <li><strong>99</strong> = neunundneunzig</li>
+      </ul>
+      <p>
+        The tens words: zwanzig (20), drei&szlig;ig (30), vierzig (40), f&uuml;nfzig (50), sechzig (60),
+        siebzig (70), achtzig (80), neunzig (90).
+      </p>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 23, 45, 88?</summary>
+        <p><strong>23</strong> dreiundzwanzig &middot; <strong>45</strong> f&uuml;nfundvierzig &middot; <strong>88</strong> achtundachtzig</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <ul>
+        <li><strong>100</strong> = (ein)hundert</li>
+        <li><strong>200</strong> = zweihundert</li>
+        <li><strong>300</strong> = dreihundert</li>
+        <li><strong>123</strong> = (ein)hundertdreiundzwanzig</li>
+      </ul>
+      <p>
+        Everything is written as one long compound word with no spaces.
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands &amp; large numbers</h2>
+      <ul>
+        <li><strong>1,000</strong> = (ein)tausend</li>
+        <li><strong>2,000</strong> = zweitausend</li>
+        <li><strong>10,000</strong> = zehntausend</li>
+        <li><strong>1,000,000</strong> = eine Million</li>
+        <li><strong>1,000,000,000</strong> = eine Milliarde</li>
+      </ul>
+      <p>
+        Numbers up to 999,999 are a single compound word. <strong>Million</strong> and <strong>Milliarde</strong>
+        are separate nouns.
+      </p>
+    </section>
+
+    <section id="spelling" class="learn-section">
+      <h2>Compound words &amp; umlauts</h2>
+      <p>
+        Key spelling details:
+      </p>
+      <ul>
+        <li>All numbers under one million are written as <strong>one word</strong> (no spaces, no hyphens)</li>
+        <li>Watch for umlauts: f<strong>&uuml;</strong>nf, zw<strong>&ouml;</strong>lf, f&uuml;nfzig, drei<strong>&szlig;</strong>ig</li>
+        <li><strong>sechs</strong> loses the &ldquo;s&rdquo;: sech<em>zehn</em>, sech<em>zig</em></li>
+        <li><strong>sieben</strong> shortens to sieb-: sieb<em>zehn</em>, sieb<em>zig</em></li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Common mistakes</h2>
+      <ol>
+        <li><strong>Word order</strong>: 42 is <em>zwei</em>und<em>vierzig</em>, not vierzig-und-zwei.</li>
+        <li><strong>eins vs. ein</strong>: &ldquo;eins&rdquo; stands alone, but &ldquo;ein&rdquo; in compounds (einundzwanzig, einhundert).</li>
+        <li><strong>drei&szlig;ig</strong>: uses &ldquo;&szlig;&rdquo; (not &ldquo;z&rdquo;) &mdash; the only tens word that doesn&rsquo;t end in -zig.</li>
+        <li><strong>Spaces</strong>: do not add spaces within numbers under one million.</li>
+        <li><strong>sechzehn / siebzehn</strong>: shortened stems, not &ldquo;sechszehn&rdquo; or &ldquo;siebenzehn&rdquo;.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_fr_de.html
+++ b/templates/learn_fr_de.html
@@ -1,0 +1,174 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>Franz&ouml;sische Zahlen lernen</h1>
+      <p>
+        Diese Seite erkl&auml;rt die wichtigsten Muster f&uuml;r <strong>franz&ouml;sische Zahlw&ouml;rter</strong> &mdash; inklusive der ber&uuml;hmten
+        Besonderheiten <em>soixante-dix</em>, <em>quatre-vingts</em> und <em>quatre-vingt-dix</em>.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;16: unregelm&auml;&szlig;ige Grundzahlen</a></li>
+        <li><a href="#teens">17&ndash;19: dix-sept-Muster</a></li>
+        <li><a href="#tens">20&ndash;69: regelm&auml;&szlig;ige Zehner</a></li>
+        <li><a href="#seventies">70&ndash;79: soixante-dix</a></li>
+        <li><a href="#eighties">80&ndash;89: quatre-vingts</a></li>
+        <li><a href="#nineties">90&ndash;99: quatre-vingt-dix</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender &amp; gro&szlig;e Zahlen</a></li>
+        <li><a href="#mistakes">Typische Fehler</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;16: unregelm&auml;&szlig;ige Grundzahlen</h2>
+      <p>
+        <strong>0&ndash;16</strong> sind eigenst&auml;ndige W&ouml;rter:
+        z&eacute;ro, un, deux, trois, quatre, cinq, six, sept, huit, neuf, dix,
+        onze, douze, treize, quatorze, quinze, seize.
+      </p>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>17&ndash;19: dix-sept-Muster</h2>
+      <p>
+        Ab 17 gilt: <strong>dix-</strong> + Einer:
+      </p>
+      <ul>
+        <li><strong>17</strong> = dix-sept</li>
+        <li><strong>18</strong> = dix-huit</li>
+        <li><strong>19</strong> = dix-neuf</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;69: regelm&auml;&szlig;ige Zehner</h2>
+      <p>
+        Die Zehner: vingt (20), trente (30), quarante (40), cinquante (50), soixante (60).
+        Mit <strong>et un</strong> f&uuml;r die 1, sonst mit Bindestrich:
+      </p>
+      <ul>
+        <li><strong>21</strong> = vingt et un</li>
+        <li><strong>22</strong> = vingt-deux</li>
+        <li><strong>31</strong> = trente et un</li>
+        <li><strong>45</strong> = quarante-cinq</li>
+        <li><strong>68</strong> = soixante-huit</li>
+      </ul>
+      <p>
+        <strong>et</strong> wird nur bei der 1 verwendet (vingt et un, trente et un usw.).
+      </p>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 21, 35, 52?</summary>
+        <p><strong>21</strong> vingt et un &middot; <strong>35</strong> trente-cinq &middot; <strong>52</strong> cinquante-deux</p>
+      </details>
+    </section>
+
+    <section id="seventies" class="learn-section">
+      <h2>70&ndash;79: soixante-dix</h2>
+      <p>
+        Franz&ouml;sisch nutzt <strong>60 + 10&ndash;19</strong> statt eines eigenen Wortes f&uuml;r 70:
+      </p>
+      <ul>
+        <li><strong>70</strong> = soixante-dix</li>
+        <li><strong>71</strong> = soixante et onze</li>
+        <li><strong>72</strong> = soixante-douze</li>
+        <li><strong>79</strong> = soixante-dix-neuf</li>
+      </ul>
+    </section>
+
+    <section id="eighties" class="learn-section">
+      <h2>80&ndash;89: quatre-vingts</h2>
+      <p>
+        80 bedeutet w&ouml;rtlich <strong>vier mal zwanzig</strong>:
+      </p>
+      <ul>
+        <li><strong>80</strong> = quatre-vingts (mit <strong>-s</strong>)</li>
+        <li><strong>81</strong> = quatre-vingt-un (ohne <strong>-s</strong>, ohne <strong>et</strong>)</li>
+        <li><strong>85</strong> = quatre-vingt-cinq</li>
+      </ul>
+      <p>
+        Das <strong>-s</strong> bei <em>vingts</em> f&auml;llt weg, wenn eine weitere Zahl folgt.
+      </p>
+    </section>
+
+    <section id="nineties" class="learn-section">
+      <h2>90&ndash;99: quatre-vingt-dix</h2>
+      <p>
+        90 ist <strong>80 + 10</strong>, weiter wie beim Siebziger-Muster:
+      </p>
+      <ul>
+        <li><strong>90</strong> = quatre-vingt-dix</li>
+        <li><strong>91</strong> = quatre-vingt-onze</li>
+        <li><strong>99</strong> = quatre-vingt-dix-neuf</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 71, 80, 95?</summary>
+        <p><strong>71</strong> soixante et onze &middot; <strong>80</strong> quatre-vingts &middot; <strong>95</strong> quatre-vingt-quinze</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <ul>
+        <li><strong>100</strong> = cent</li>
+        <li><strong>200</strong> = deux cents (mit <strong>-s</strong>)</li>
+        <li><strong>201</strong> = deux cent un (ohne <strong>-s</strong>, wenn weitere Zahlen folgen)</li>
+        <li><strong>500</strong> = cinq cents</li>
+      </ul>
+      <p>
+        Regel: <strong>cents</strong> bekommt ein <strong>-s</strong> nur, wenn es das letzte Wort ist (deux cents, trois cents),
+        aber nicht, wenn eine weitere Zahl folgt (deux cent un).
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender &amp; gro&szlig;e Zahlen</h2>
+      <ul>
+        <li><strong>1 000</strong> = mille (nie &bdquo;un mille&ldquo;)</li>
+        <li><strong>2 000</strong> = deux mille</li>
+        <li><strong>1 000 000</strong> = un million</li>
+        <li><strong>2 000 000</strong> = deux millions</li>
+        <li><strong>1 000 000 000</strong> = un milliard</li>
+      </ul>
+      <p>
+        <strong>Mille</strong> ist unveränderlich (nie mit -s). <strong>Million</strong> und <strong>milliard</strong>
+        sind Substantive und werden im Plural mit -s geschrieben.
+      </p>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Typische Fehler</h2>
+      <ol>
+        <li><strong>quatre-vingts vs. quatre-vingt-un</strong>: das -s f&auml;llt weg, sobald eine weitere Zahl folgt.</li>
+        <li><strong>deux cents vs. deux cent un</strong>: gleiche Regel bei Hundertern.</li>
+        <li><strong>soixante et onze</strong> (71): das <strong>et</strong> nicht vergessen.</li>
+        <li><strong>mille</strong>: nie &bdquo;un mille&ldquo;, nie &bdquo;milles&ldquo;.</li>
+        <li><strong>Bindestriche</strong>: zwischen allen Zahlw&ouml;rtern unter 100 erforderlich (neue Rechtschreibung).</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_fr_en.html
+++ b/templates/learn_fr_en.html
@@ -1,0 +1,174 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn French Numbers</h1>
+      <p>
+        This page covers the key patterns for <strong>French number words</strong> &mdash; including the famous
+        <em>soixante-dix</em>, <em>quatre-vingts</em>, and <em>quatre-vingt-dix</em> quirks.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;16: irregular bases</a></li>
+        <li><a href="#teens">17&ndash;19: dix-sept pattern</a></li>
+        <li><a href="#tens">20&ndash;69: regular tens</a></li>
+        <li><a href="#seventies">70&ndash;79: soixante-dix</a></li>
+        <li><a href="#eighties">80&ndash;89: quatre-vingts</a></li>
+        <li><a href="#nineties">90&ndash;99: quatre-vingt-dix</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands &amp; large numbers</a></li>
+        <li><a href="#mistakes">Common mistakes</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;16: irregular bases</h2>
+      <p>
+        Memorize <strong>0&ndash;16</strong> as unique words:
+        z&eacute;ro, un, deux, trois, quatre, cinq, six, sept, huit, neuf, dix,
+        onze, douze, treize, quatorze, quinze, seize.
+      </p>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>17&ndash;19: dix-sept pattern</h2>
+      <p>
+        From 17, the pattern is <strong>dix-</strong> + unit:
+      </p>
+      <ul>
+        <li><strong>17</strong> = dix-sept</li>
+        <li><strong>18</strong> = dix-huit</li>
+        <li><strong>19</strong> = dix-neuf</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;69: regular tens</h2>
+      <p>
+        The tens are: vingt (20), trente (30), quarante (40), cinquante (50), soixante (60).
+        Combine with <strong>et un</strong> for 1, or a hyphen for 2&ndash;9:
+      </p>
+      <ul>
+        <li><strong>21</strong> = vingt et un</li>
+        <li><strong>22</strong> = vingt-deux</li>
+        <li><strong>31</strong> = trente et un</li>
+        <li><strong>45</strong> = quarante-cinq</li>
+        <li><strong>68</strong> = soixante-huit</li>
+      </ul>
+      <p>
+        Note: <strong>et</strong> is used only with 1 (vingt et un, trente et un, etc.), never with other digits.
+      </p>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 21, 35, 52?</summary>
+        <p><strong>21</strong> vingt et un &middot; <strong>35</strong> trente-cinq &middot; <strong>52</strong> cinquante-deux</p>
+      </details>
+    </section>
+
+    <section id="seventies" class="learn-section">
+      <h2>70&ndash;79: soixante-dix</h2>
+      <p>
+        French uses <strong>60 + 10&ndash;19</strong> instead of a separate word for 70:
+      </p>
+      <ul>
+        <li><strong>70</strong> = soixante-dix</li>
+        <li><strong>71</strong> = soixante et onze</li>
+        <li><strong>72</strong> = soixante-douze</li>
+        <li><strong>79</strong> = soixante-dix-neuf</li>
+      </ul>
+    </section>
+
+    <section id="eighties" class="learn-section">
+      <h2>80&ndash;89: quatre-vingts</h2>
+      <p>
+        80 literally means <strong>four twenties</strong>:
+      </p>
+      <ul>
+        <li><strong>80</strong> = quatre-vingts (note the <strong>-s</strong>)</li>
+        <li><strong>81</strong> = quatre-vingt-un (no <strong>-s</strong>, no <strong>et</strong>)</li>
+        <li><strong>85</strong> = quatre-vingt-cinq</li>
+      </ul>
+      <p>
+        The <strong>-s</strong> on <em>vingts</em> disappears when followed by another number.
+      </p>
+    </section>
+
+    <section id="nineties" class="learn-section">
+      <h2>90&ndash;99: quatre-vingt-dix</h2>
+      <p>
+        90 is <strong>80 + 10</strong>, then continues like the seventies pattern:
+      </p>
+      <ul>
+        <li><strong>90</strong> = quatre-vingt-dix</li>
+        <li><strong>91</strong> = quatre-vingt-onze</li>
+        <li><strong>99</strong> = quatre-vingt-dix-neuf</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 71, 80, 95?</summary>
+        <p><strong>71</strong> soixante et onze &middot; <strong>80</strong> quatre-vingts &middot; <strong>95</strong> quatre-vingt-quinze</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <ul>
+        <li><strong>100</strong> = cent</li>
+        <li><strong>200</strong> = deux cents (with <strong>-s</strong>)</li>
+        <li><strong>201</strong> = deux cent un (no <strong>-s</strong> when followed by more)</li>
+        <li><strong>500</strong> = cinq cents</li>
+      </ul>
+      <p>
+        Rule: <strong>cents</strong> takes an <strong>-s</strong> only when it is the last word (deux cents, trois cents),
+        but not when followed by another number (deux cent un).
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands &amp; large numbers</h2>
+      <ul>
+        <li><strong>1,000</strong> = mille (never "un mille")</li>
+        <li><strong>2,000</strong> = deux mille</li>
+        <li><strong>1,000,000</strong> = un million</li>
+        <li><strong>2,000,000</strong> = deux millions</li>
+        <li><strong>1,000,000,000</strong> = un milliard</li>
+      </ul>
+      <p>
+        <strong>Mille</strong> is invariable (never takes -s). <strong>Million</strong> and <strong>milliard</strong>
+        are nouns and do take -s in the plural.
+      </p>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Common mistakes</h2>
+      <ol>
+        <li><strong>quatre-vingts vs. quatre-vingt-un</strong>: the -s disappears before another number.</li>
+        <li><strong>deux cents vs. deux cent un</strong>: same rule for hundreds.</li>
+        <li><strong>soixante et onze</strong> (71): don&rsquo;t forget the <strong>et</strong>.</li>
+        <li><strong>mille</strong>: never "un mille", never "milles".</li>
+        <li><strong>Hyphens</strong>: required between all number words under 100 (modern spelling reform).</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_it_de.html
+++ b/templates/learn_it_de.html
@@ -1,0 +1,134 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>Italienische Zahlen lernen</h1>
+      <p>
+        Diese Seite erkl&auml;rt <strong>italienische Zahlw&ouml;rter</strong> &mdash; Vokalelision, Akzentregeln
+        und die kniffligen Stellen wie <em>ventuno</em> und <em>ventitr&eacute;</em>.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;19: Grundbausteine</a></li>
+        <li><a href="#tens">20&ndash;99: Zehner &amp; Elision</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender &amp; gro&szlig;e Zahlen</a></li>
+        <li><a href="#mistakes">Typische Fehler</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;19: Grundbausteine</h2>
+      <p>Einzeln auswendig lernen:</p>
+      <ul>
+        <li><strong>0</strong> = zero</li>
+        <li><strong>1</strong> = uno</li>
+        <li><strong>2</strong> = due</li>
+        <li><strong>3</strong> = tre</li>
+        <li><strong>4</strong> = quattro</li>
+        <li><strong>5</strong> = cinque</li>
+        <li><strong>6</strong> = sei</li>
+        <li><strong>7</strong> = sette</li>
+        <li><strong>8</strong> = otto</li>
+        <li><strong>9</strong> = nove</li>
+        <li><strong>10</strong> = dieci</li>
+        <li><strong>11</strong> = undici</li>
+        <li><strong>12</strong> = dodici</li>
+        <li><strong>13</strong> = tredici</li>
+        <li><strong>14</strong> = quattordici</li>
+        <li><strong>15</strong> = quindici</li>
+        <li><strong>16</strong> = sedici</li>
+        <li><strong>17</strong> = diciassette</li>
+        <li><strong>18</strong> = diciotto</li>
+        <li><strong>19</strong> = diciannove</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: Zehner &amp; Vokalelision</h2>
+      <p>
+        Die Zehner: venti (20), trenta (30), quaranta (40), cinquanta (50), sessanta (60),
+        settanta (70), ottanta (80), novanta (90).
+      </p>
+      <p>
+        Wenn der Einer mit einem Vokal beginnt (<strong>uno</strong> oder <strong>otto</strong>), f&auml;llt der Endvokal des Zehners <strong>weg</strong>:
+      </p>
+      <ul>
+        <li><strong>21</strong> = vent<strong>uno</strong> (nicht &bdquo;ventiuno&ldquo;)</li>
+        <li><strong>28</strong> = vent<strong>otto</strong> (nicht &bdquo;ventiotto&ldquo;)</li>
+        <li><strong>38</strong> = trent<strong>otto</strong></li>
+      </ul>
+      <p>
+        Akzentregel: Zusammensetzungen mit <strong>tre</strong> bekommen einen Akzent: venti<strong>tr&eacute;</strong>, trenta<strong>tr&eacute;</strong> usw.
+      </p>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 21, 33, 48?</summary>
+        <p><strong>21</strong> ventuno &middot; <strong>33</strong> trentatr&eacute; &middot; <strong>48</strong> quarantotto</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <ul>
+        <li><strong>100</strong> = cento</li>
+        <li><strong>200</strong> = duecento</li>
+        <li><strong>300</strong> = trecento</li>
+        <li><strong>500</strong> = cinquecento</li>
+        <li><strong>101</strong> = centuno (Elision mit uno)</li>
+      </ul>
+      <p>
+        Alle Hunderter werden als ein Wort geschrieben. Die Elision gilt auch nach cento bei <strong>uno</strong> und <strong>otto</strong>.
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender &amp; gro&szlig;e Zahlen</h2>
+      <ul>
+        <li><strong>1.000</strong> = mille</li>
+        <li><strong>2.000</strong> = duemila (<strong>mila</strong> im Plural)</li>
+        <li><strong>3.000</strong> = tremila</li>
+        <li><strong>10.000</strong> = diecimila</li>
+        <li><strong>1.000.000</strong> = un milione</li>
+        <li><strong>2.000.000</strong> = due milioni</li>
+        <li><strong>1.000.000.000</strong> = un miliardo</li>
+      </ul>
+      <p>
+        <strong>Mille</strong> wird im Plural zu <strong>mila</strong>. <strong>Milione</strong> und <strong>miliardo</strong>
+        sind Substantive mit regul&auml;rem Plural.
+      </p>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Typische Fehler</h2>
+      <ol>
+        <li><strong>Vokalelision</strong>: ventuno (nicht ventiuno), ventotto (nicht ventiotto).</li>
+        <li><strong>Akzent bei -tr&eacute;</strong>: ventitr&eacute;, trentatr&eacute; usw.</li>
+        <li><strong>mille vs. mila</strong>: mille (1.000), aber duemila, tremila usw.</li>
+        <li><strong>milione ist ein Substantiv</strong>: &bdquo;un milione&ldquo; (nicht &bdquo;mille mille&ldquo;).</li>
+        <li><strong>diciassette / diciannove</strong>: Doppelbuchstaben (ss, nn).</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_it_en.html
+++ b/templates/learn_it_en.html
@@ -1,0 +1,134 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn Italian Numbers</h1>
+      <p>
+        This page covers <strong>Italian number words</strong> &mdash; vowel elision, accent rules,
+        and the tricky parts like <em>ventuno</em> and <em>ventitr&eacute;</em>.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;19: building blocks</a></li>
+        <li><a href="#tens">20&ndash;99: tens &amp; elision</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands &amp; large numbers</a></li>
+        <li><a href="#mistakes">Common mistakes</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;19: building blocks</h2>
+      <p>Memorize these individually:</p>
+      <ul>
+        <li><strong>0</strong> = zero</li>
+        <li><strong>1</strong> = uno</li>
+        <li><strong>2</strong> = due</li>
+        <li><strong>3</strong> = tre</li>
+        <li><strong>4</strong> = quattro</li>
+        <li><strong>5</strong> = cinque</li>
+        <li><strong>6</strong> = sei</li>
+        <li><strong>7</strong> = sette</li>
+        <li><strong>8</strong> = otto</li>
+        <li><strong>9</strong> = nove</li>
+        <li><strong>10</strong> = dieci</li>
+        <li><strong>11</strong> = undici</li>
+        <li><strong>12</strong> = dodici</li>
+        <li><strong>13</strong> = tredici</li>
+        <li><strong>14</strong> = quattordici</li>
+        <li><strong>15</strong> = quindici</li>
+        <li><strong>16</strong> = sedici</li>
+        <li><strong>17</strong> = diciassette</li>
+        <li><strong>18</strong> = diciotto</li>
+        <li><strong>19</strong> = diciannove</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: tens &amp; vowel elision</h2>
+      <p>
+        The tens: venti (20), trenta (30), quaranta (40), cinquanta (50), sessanta (60),
+        settanta (70), ottanta (80), novanta (90).
+      </p>
+      <p>
+        When the ones digit starts with a vowel (<strong>uno</strong> or <strong>otto</strong>), the final vowel of the tens word is <strong>dropped</strong>:
+      </p>
+      <ul>
+        <li><strong>21</strong> = vent<strong>uno</strong> (not &ldquo;ventiuno&rdquo;)</li>
+        <li><strong>28</strong> = vent<strong>otto</strong> (not &ldquo;ventiotto&rdquo;)</li>
+        <li><strong>38</strong> = trent<strong>otto</strong></li>
+      </ul>
+      <p>
+        The accent rule: compounds with <strong>tre</strong> get an accent: venti<strong>tr&eacute;</strong>, trenta<strong>tr&eacute;</strong>, etc.
+      </p>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 21, 33, 48?</summary>
+        <p><strong>21</strong> ventuno &middot; <strong>33</strong> trentatr&eacute; &middot; <strong>48</strong> quarantotto</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <ul>
+        <li><strong>100</strong> = cento</li>
+        <li><strong>200</strong> = duecento</li>
+        <li><strong>300</strong> = trecento</li>
+        <li><strong>500</strong> = cinquecento</li>
+        <li><strong>101</strong> = centuno (elision with uno)</li>
+      </ul>
+      <p>
+        All hundreds are written as one word. Elision applies with <strong>uno</strong> and <strong>otto</strong> after cento too.
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands &amp; large numbers</h2>
+      <ul>
+        <li><strong>1,000</strong> = mille</li>
+        <li><strong>2,000</strong> = duemila (note: <strong>mila</strong> in plural)</li>
+        <li><strong>3,000</strong> = tremila</li>
+        <li><strong>10,000</strong> = diecimila</li>
+        <li><strong>1,000,000</strong> = un milione</li>
+        <li><strong>2,000,000</strong> = due milioni</li>
+        <li><strong>1,000,000,000</strong> = un miliardo</li>
+      </ul>
+      <p>
+        <strong>Mille</strong> becomes <strong>mila</strong> in plural. <strong>Milione</strong> and <strong>miliardo</strong>
+        are nouns with regular plurals.
+      </p>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Common mistakes</h2>
+      <ol>
+        <li><strong>Vowel elision</strong>: ventuno (not ventiuno), ventotto (not ventiotto).</li>
+        <li><strong>Accent on -tr&eacute;</strong>: ventitr&eacute;, trentatr&eacute;, etc.</li>
+        <li><strong>mille vs. mila</strong>: mille (1,000) but duemila, tremila, etc.</li>
+        <li><strong>milione is a noun</strong>: &ldquo;un milione&rdquo; (not &ldquo;mille mille&rdquo;).</li>
+        <li><strong>diciassette / diciannove</strong>: double letters (ss, nn).</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_ja_de.html
+++ b/templates/learn_ja_de.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>Japanische Zahlen lernen</h1>
+      <p>
+        Diese Seite erkl&auml;rt <strong>japanische Zahlw&ouml;rter</strong> in Kanji.
+        Das japanische Zahlensystem ist sehr regelm&auml;&szlig;ig, sobald man die Grundziffern und Stellenwerte kennt.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#digits">Ziffern: 0&ndash;9</a></li>
+        <li><a href="#tens">10&ndash;99: Zehner</a></li>
+        <li><a href="#hundreds">100&ndash;999: Hunderter</a></li>
+        <li><a href="#thousands">1.000&ndash;9.999: Tausender</a></li>
+        <li><a href="#large">Gro&szlig;e Zahlen: &#19975; (10.000+)</a></li>
+        <li><a href="#exceptions">Unregelm&auml;&szlig;ige Lesungen</a></li>
+      </ul>
+    </nav>
+
+    <section id="digits" class="learn-section">
+      <h2>Ziffern: 0&ndash;9</h2>
+      <ul>
+        <li><strong>0</strong> = &#38646; (rei/zero)</li>
+        <li><strong>1</strong> = &#19968; (ichi)</li>
+        <li><strong>2</strong> = &#20108; (ni)</li>
+        <li><strong>3</strong> = &#19977; (san)</li>
+        <li><strong>4</strong> = &#22235; (yon/shi)</li>
+        <li><strong>5</strong> = &#20116; (go)</li>
+        <li><strong>6</strong> = &#20845; (roku)</li>
+        <li><strong>7</strong> = &#19971; (nana/shichi)</li>
+        <li><strong>8</strong> = &#20843; (hachi)</li>
+        <li><strong>9</strong> = &#20061; (ky&uuml;/ku)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>10&ndash;99: Zehner</h2>
+      <p>
+        <strong>&#21313;</strong> (j&uuml;) bedeutet 10. Ziffer + &#21313; f&uuml;r Vielfache von zehn, &#21313; + Ziffer f&uuml;r 11&ndash;19:
+      </p>
+      <ul>
+        <li><strong>10</strong> = &#21313;</li>
+        <li><strong>11</strong> = &#21313;&#19968;</li>
+        <li><strong>20</strong> = &#20108;&#21313;</li>
+        <li><strong>25</strong> = &#20108;&#21313;&#20116;</li>
+        <li><strong>99</strong> = &#20061;&#21313;&#20061;</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 14, 30, 67?</summary>
+        <p><strong>14</strong> &#21313;&#22235; &middot; <strong>30</strong> &#19977;&#21313; &middot; <strong>67</strong> &#20845;&#21313;&#19971;</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>100&ndash;999: Hunderter</h2>
+      <p>
+        <strong>&#30334;</strong> (hyaku) bedeutet 100:
+      </p>
+      <ul>
+        <li><strong>100</strong> = &#30334;</li>
+        <li><strong>200</strong> = &#20108;&#30334;</li>
+        <li><strong>300</strong> = &#19977;&#30334; (sanbyaku &mdash; Lautver&auml;nderung)</li>
+        <li><strong>456</strong> = &#22235;&#30334;&#20116;&#21313;&#20845;</li>
+        <li><strong>600</strong> = &#20845;&#30334; (roppyaku &mdash; Lautver&auml;nderung)</li>
+        <li><strong>800</strong> = &#20843;&#30334; (happyaku &mdash; Lautver&auml;nderung)</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>1.000&ndash;9.999: Tausender</h2>
+      <p>
+        <strong>&#21315;</strong> (sen) bedeutet 1.000:
+      </p>
+      <ul>
+        <li><strong>1.000</strong> = &#21315;</li>
+        <li><strong>2.000</strong> = &#20108;&#21315;</li>
+        <li><strong>3.000</strong> = &#19977;&#21315; (sanzen &mdash; Lautver&auml;nderung)</li>
+        <li><strong>8.000</strong> = &#20843;&#21315; (hassen &mdash; Lautver&auml;nderung)</li>
+        <li><strong>5.432</strong> = &#20116;&#21315;&#22235;&#30334;&#19977;&#21313;&#20108;</li>
+      </ul>
+    </section>
+
+    <section id="large" class="learn-section">
+      <h2>Gro&szlig;e Zahlen: &#19975; (10.000+)</h2>
+      <p>
+        Anders als in westlichen Sprachen gruppiert Japanisch in Einheiten von <strong>10.000</strong> (&#19975;, man):
+      </p>
+      <ul>
+        <li><strong>10.000</strong> = &#19968;&#19975;</li>
+        <li><strong>100.000</strong> = &#21313;&#19975;</li>
+        <li><strong>1.000.000</strong> = &#30334;&#19975;</li>
+      </ul>
+    </section>
+
+    <section id="exceptions" class="learn-section">
+      <h2>Unregelm&auml;&szlig;ige Lesungen</h2>
+      <p>
+        Die Kanji bleiben gleich, aber in der Aussprache gibt es Lautver&auml;nderungen:
+      </p>
+      <ol>
+        <li><strong>300</strong> &#19977;&#30334; = <em>sanbyaku</em> (nicht san-hyaku)</li>
+        <li><strong>600</strong> &#20845;&#30334; = <em>roppyaku</em> (nicht roku-hyaku)</li>
+        <li><strong>800</strong> &#20843;&#30334; = <em>happyaku</em> (nicht hachi-hyaku)</li>
+        <li><strong>3.000</strong> &#19977;&#21315; = <em>sanzen</em> (nicht san-sen)</li>
+        <li><strong>8.000</strong> &#20843;&#21315; = <em>hassen</em> (nicht hachi-sen)</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_ja_en.html
+++ b/templates/learn_ja_en.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn Japanese Numbers</h1>
+      <p>
+        This page covers <strong>Japanese number words</strong> using kanji.
+        Japanese numbers follow a very regular positional system once you know the basic digits and place values.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#digits">Digits: 0&ndash;9</a></li>
+        <li><a href="#tens">10&ndash;99: tens</a></li>
+        <li><a href="#hundreds">100&ndash;999: hundreds</a></li>
+        <li><a href="#thousands">1,000&ndash;9,999: thousands</a></li>
+        <li><a href="#large">Large numbers: &#19975; (10,000+)</a></li>
+        <li><a href="#exceptions">Irregular readings</a></li>
+      </ul>
+    </nav>
+
+    <section id="digits" class="learn-section">
+      <h2>Digits: 0&ndash;9</h2>
+      <ul>
+        <li><strong>0</strong> = &#38646; (rei/zero)</li>
+        <li><strong>1</strong> = &#19968; (ichi)</li>
+        <li><strong>2</strong> = &#20108; (ni)</li>
+        <li><strong>3</strong> = &#19977; (san)</li>
+        <li><strong>4</strong> = &#22235; (yon/shi)</li>
+        <li><strong>5</strong> = &#20116; (go)</li>
+        <li><strong>6</strong> = &#20845; (roku)</li>
+        <li><strong>7</strong> = &#19971; (nana/shichi)</li>
+        <li><strong>8</strong> = &#20843; (hachi)</li>
+        <li><strong>9</strong> = &#20061; (ky&uuml;/ku)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>10&ndash;99: tens</h2>
+      <p>
+        <strong>&#21313;</strong> (j&uuml;) means 10. Combine digit + &#21313; for multiples of ten, and &#21313; + digit for teens:
+      </p>
+      <ul>
+        <li><strong>10</strong> = &#21313;</li>
+        <li><strong>11</strong> = &#21313;&#19968;</li>
+        <li><strong>20</strong> = &#20108;&#21313;</li>
+        <li><strong>25</strong> = &#20108;&#21313;&#20116;</li>
+        <li><strong>99</strong> = &#20061;&#21313;&#20061;</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 14, 30, 67?</summary>
+        <p><strong>14</strong> &#21313;&#22235; &middot; <strong>30</strong> &#19977;&#21313; &middot; <strong>67</strong> &#20845;&#21313;&#19971;</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>100&ndash;999: hundreds</h2>
+      <p>
+        <strong>&#30334;</strong> (hyaku) means 100:
+      </p>
+      <ul>
+        <li><strong>100</strong> = &#30334;</li>
+        <li><strong>200</strong> = &#20108;&#30334;</li>
+        <li><strong>300</strong> = &#19977;&#30334; (sanbyaku &mdash; sound change)</li>
+        <li><strong>456</strong> = &#22235;&#30334;&#20116;&#21313;&#20845;</li>
+        <li><strong>600</strong> = &#20845;&#30334; (roppyaku &mdash; sound change)</li>
+        <li><strong>800</strong> = &#20843;&#30334; (happyaku &mdash; sound change)</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>1,000&ndash;9,999: thousands</h2>
+      <p>
+        <strong>&#21315;</strong> (sen) means 1,000:
+      </p>
+      <ul>
+        <li><strong>1,000</strong> = &#21315;</li>
+        <li><strong>2,000</strong> = &#20108;&#21315;</li>
+        <li><strong>3,000</strong> = &#19977;&#21315; (sanzen &mdash; sound change)</li>
+        <li><strong>8,000</strong> = &#20843;&#21315; (hassen &mdash; sound change)</li>
+        <li><strong>5,432</strong> = &#20116;&#21315;&#22235;&#30334;&#19977;&#21313;&#20108;</li>
+      </ul>
+    </section>
+
+    <section id="large" class="learn-section">
+      <h2>Large numbers: &#19975; (10,000+)</h2>
+      <p>
+        Unlike Western languages, Japanese groups numbers in units of <strong>10,000</strong> (&#19975;, man):
+      </p>
+      <ul>
+        <li><strong>10,000</strong> = &#19968;&#19975;</li>
+        <li><strong>100,000</strong> = &#21313;&#19975;</li>
+        <li><strong>1,000,000</strong> = &#30334;&#19975;</li>
+      </ul>
+    </section>
+
+    <section id="exceptions" class="learn-section">
+      <h2>Irregular readings</h2>
+      <p>
+        In kanji writing the characters stay the same, but be aware of sound changes in spoken Japanese:
+      </p>
+      <ol>
+        <li><strong>300</strong> &#19977;&#30334; = <em>sanbyaku</em> (not san-hyaku)</li>
+        <li><strong>600</strong> &#20845;&#30334; = <em>roppyaku</em> (not roku-hyaku)</li>
+        <li><strong>800</strong> &#20843;&#30334; = <em>happyaku</em> (not hachi-hyaku)</li>
+        <li><strong>3,000</strong> &#19977;&#21315; = <em>sanzen</em> (not san-sen)</li>
+        <li><strong>8,000</strong> &#20843;&#21315; = <em>hassen</em> (not hachi-sen)</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_ko_de.html
+++ b/templates/learn_ko_de.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>Koreanische Zahlen lernen</h1>
+      <p>
+        Diese Seite behandelt das <strong>sinokoreanische Zahlensystem</strong> (&#51068;, &#51060;, &#49340;&hellip;),
+        das f&uuml;r gro&szlig;e Zahlen, Daten, Geldbetr&auml;ge und Telefonnummern verwendet wird.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#digits">Ziffern: 0&ndash;9</a></li>
+        <li><a href="#tens">10&ndash;99: Zehner</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender</a></li>
+        <li><a href="#large">Gro&szlig;e Zahlen: &#47564; (10.000+)</a></li>
+      </ul>
+    </nav>
+
+    <section id="digits" class="learn-section">
+      <h2>Ziffern: 0&ndash;9</h2>
+      <ul>
+        <li><strong>0</strong> = &#50689; (yeong)</li>
+        <li><strong>1</strong> = &#51068; (il)</li>
+        <li><strong>2</strong> = &#51060; (i)</li>
+        <li><strong>3</strong> = &#49340; (sam)</li>
+        <li><strong>4</strong> = &#49324; (sa)</li>
+        <li><strong>5</strong> = &#50724; (o)</li>
+        <li><strong>6</strong> = &#50977; (yuk)</li>
+        <li><strong>7</strong> = &#52832; (chil)</li>
+        <li><strong>8</strong> = &#54036; (pal)</li>
+        <li><strong>9</strong> = &#44396; (gu)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>10&ndash;99: Zehner</h2>
+      <p>
+        <strong>&#49901;</strong> (sip) bedeutet 10. Das System ist vollkommen regelm&auml;&szlig;ig:
+      </p>
+      <ul>
+        <li><strong>10</strong> = &#49901;</li>
+        <li><strong>11</strong> = &#49901;&#51068;</li>
+        <li><strong>20</strong> = &#51060;&#49901;</li>
+        <li><strong>35</strong> = &#49340;&#49901;&#50724;</li>
+        <li><strong>99</strong> = &#44396;&#49901;&#44396;</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 15, 42, 78?</summary>
+        <p><strong>15</strong> &#49901;&#50724; &middot; <strong>42</strong> &#49324;&#49901;&#51060; &middot; <strong>78</strong> &#52832;&#49901;&#54036;</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <p>
+        <strong>&#48177;</strong> (baek) bedeutet 100:
+      </p>
+      <ul>
+        <li><strong>100</strong> = &#48177;</li>
+        <li><strong>200</strong> = &#51060;&#48177;</li>
+        <li><strong>500</strong> = &#50724;&#48177;</li>
+        <li><strong>321</strong> = &#49340;&#48177;&#51060;&#49901;&#51068;</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender</h2>
+      <p>
+        <strong>&#52380;</strong> (cheon) bedeutet 1.000:
+      </p>
+      <ul>
+        <li><strong>1.000</strong> = &#52380;</li>
+        <li><strong>2.000</strong> = &#51060;&#52380;</li>
+        <li><strong>5.678</strong> = &#50724;&#52380;&#50977;&#48177;&#52832;&#49901;&#54036;</li>
+      </ul>
+    </section>
+
+    <section id="large" class="learn-section">
+      <h2>Gro&szlig;e Zahlen: &#47564; (10.000+)</h2>
+      <p>
+        Wie im Japanischen gruppiert Koreanisch in Einheiten von <strong>10.000</strong> (&#47564;, man):
+      </p>
+      <ul>
+        <li><strong>10.000</strong> = &#47564;</li>
+        <li><strong>100.000</strong> = &#49901;&#47564;</li>
+        <li><strong>1.000.000</strong> = &#48177;&#47564;</li>
+      </ul>
+      <p>
+        Das sinokoreanische System ist sehr regelm&auml;&szlig;ig &mdash; sobald man die Ziffern und Stellenwerte kennt, kann man jede Zahl bilden.
+      </p>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_ko_en.html
+++ b/templates/learn_ko_en.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn Korean Numbers</h1>
+      <p>
+        This page covers the <strong>Sino-Korean number system</strong> (&#51068;, &#51060;, &#49340;&hellip;),
+        which is the system used for large numbers, dates, money, and phone numbers.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#digits">Digits: 0&ndash;9</a></li>
+        <li><a href="#tens">10&ndash;99: tens</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands</a></li>
+        <li><a href="#large">Large numbers: &#47564; (10,000+)</a></li>
+      </ul>
+    </nav>
+
+    <section id="digits" class="learn-section">
+      <h2>Digits: 0&ndash;9</h2>
+      <ul>
+        <li><strong>0</strong> = &#50689; (yeong)</li>
+        <li><strong>1</strong> = &#51068; (il)</li>
+        <li><strong>2</strong> = &#51060; (i)</li>
+        <li><strong>3</strong> = &#49340; (sam)</li>
+        <li><strong>4</strong> = &#49324; (sa)</li>
+        <li><strong>5</strong> = &#50724; (o)</li>
+        <li><strong>6</strong> = &#50977; (yuk)</li>
+        <li><strong>7</strong> = &#52832; (chil)</li>
+        <li><strong>8</strong> = &#54036; (pal)</li>
+        <li><strong>9</strong> = &#44396; (gu)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>10&ndash;99: tens</h2>
+      <p>
+        <strong>&#49901;</strong> (sip) means 10. The system is fully regular:
+      </p>
+      <ul>
+        <li><strong>10</strong> = &#49901;</li>
+        <li><strong>11</strong> = &#49901;&#51068;</li>
+        <li><strong>20</strong> = &#51060;&#49901;</li>
+        <li><strong>35</strong> = &#49340;&#49901;&#50724;</li>
+        <li><strong>99</strong> = &#44396;&#49901;&#44396;</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 15, 42, 78?</summary>
+        <p><strong>15</strong> &#49901;&#50724; &middot; <strong>42</strong> &#49324;&#49901;&#51060; &middot; <strong>78</strong> &#52832;&#49901;&#54036;</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <p>
+        <strong>&#48177;</strong> (baek) means 100:
+      </p>
+      <ul>
+        <li><strong>100</strong> = &#48177;</li>
+        <li><strong>200</strong> = &#51060;&#48177;</li>
+        <li><strong>500</strong> = &#50724;&#48177;</li>
+        <li><strong>321</strong> = &#49340;&#48177;&#51060;&#49901;&#51068;</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands</h2>
+      <p>
+        <strong>&#52380;</strong> (cheon) means 1,000:
+      </p>
+      <ul>
+        <li><strong>1,000</strong> = &#52380;</li>
+        <li><strong>2,000</strong> = &#51060;&#52380;</li>
+        <li><strong>5,678</strong> = &#50724;&#52380;&#50977;&#48177;&#52832;&#49901;&#54036;</li>
+      </ul>
+    </section>
+
+    <section id="large" class="learn-section">
+      <h2>Large numbers: &#47564; (10,000+)</h2>
+      <p>
+        Like Japanese, Korean groups in units of <strong>10,000</strong> (&#47564;, man):
+      </p>
+      <ul>
+        <li><strong>10,000</strong> = &#47564;</li>
+        <li><strong>100,000</strong> = &#49901;&#47564;</li>
+        <li><strong>1,000,000</strong> = &#48177;&#47564;</li>
+      </ul>
+      <p>
+        The Sino-Korean system is very regular &mdash; once you know the digits and place values, you can build any number.
+      </p>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_no_de.html
+++ b/templates/learn_no_de.html
@@ -1,0 +1,139 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>Norwegische Zahlen lernen</h1>
+      <p>
+        Diese Seite erkl&auml;rt <strong>norwegische Zahlw&ouml;rter</strong> (Bokm&aring;l). Norwegisch hat regelm&auml;&szlig;ige Zehner
+        (anders als D&auml;nisch), umgekehrte Reihenfolge bei 21&ndash;99 und einfache Zusammensetzungsregeln.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;12: unregelm&auml;&szlig;ige Grundzahlen</a></li>
+        <li><a href="#teens">13&ndash;19: Teens</a></li>
+        <li><a href="#tens">20&ndash;99: Zehner</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender &amp; gro&szlig;e Zahlen</a></li>
+        <li><a href="#mistakes">Typische Fehler</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;12: unregelm&auml;&szlig;ige Grundzahlen</h2>
+      <p>Einzeln auswendig lernen:</p>
+      <ul>
+        <li><strong>0</strong> = null</li>
+        <li><strong>1</strong> = en / ett</li>
+        <li><strong>2</strong> = to</li>
+        <li><strong>3</strong> = tre</li>
+        <li><strong>4</strong> = fire</li>
+        <li><strong>5</strong> = fem</li>
+        <li><strong>6</strong> = seks</li>
+        <li><strong>7</strong> = sju / syv</li>
+        <li><strong>8</strong> = &aring;tte</li>
+        <li><strong>9</strong> = ni</li>
+        <li><strong>10</strong> = ti</li>
+        <li><strong>11</strong> = elleve</li>
+        <li><strong>12</strong> = tolv</li>
+      </ul>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>13&ndash;19: Teens</h2>
+      <p>
+        Muster: Ziffer + <strong>ten</strong> (von &bdquo;ti&ldquo;):
+      </p>
+      <ul>
+        <li><strong>13</strong> = tretten</li>
+        <li><strong>14</strong> = fjorten</li>
+        <li><strong>15</strong> = femten</li>
+        <li><strong>16</strong> = seksten</li>
+        <li><strong>17</strong> = sytten</li>
+        <li><strong>18</strong> = atten</li>
+        <li><strong>19</strong> = nitten</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: Zehner</h2>
+      <p>
+        Norwegisch verwendet regelm&auml;&szlig;ige Dezimalzehner (anders als das d&auml;nische Vigesimalsystem):
+      </p>
+      <ul>
+        <li><strong>20</strong> = tjue</li>
+        <li><strong>30</strong> = tretti</li>
+        <li><strong>40</strong> = f&oslash;rti</li>
+        <li><strong>50</strong> = femti</li>
+        <li><strong>60</strong> = seksti</li>
+        <li><strong>70</strong> = sytti</li>
+        <li><strong>80</strong> = &aring;tti</li>
+        <li><strong>90</strong> = nitti</li>
+      </ul>
+      <p>
+        Zusammensetzungen: Einer + Zehner als ein Wort, oder mit <strong>og</strong> (&bdquo;und&ldquo;):
+      </p>
+      <ul>
+        <li><strong>21</strong> = tjueen</li>
+        <li><strong>35</strong> = trettifem</li>
+        <li><strong>99</strong> = nittini</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 22, 46, 83?</summary>
+        <p><strong>22</strong> tjueto &middot; <strong>46</strong> f&oslash;rtiseks &middot; <strong>83</strong> &aring;ttitre</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <ul>
+        <li><strong>100</strong> = (ett) hundre</li>
+        <li><strong>200</strong> = to hundre</li>
+        <li><strong>300</strong> = tre hundre</li>
+        <li><strong>150</strong> = (ett) hundre og femti</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender &amp; gro&szlig;e Zahlen</h2>
+      <ul>
+        <li><strong>1.000</strong> = (ett) tusen</li>
+        <li><strong>2.000</strong> = to tusen</li>
+        <li><strong>10.000</strong> = ti tusen</li>
+        <li><strong>1.000.000</strong> = en million</li>
+        <li><strong>1.000.000.000</strong> = en milliard</li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Typische Fehler</h2>
+      <ol>
+        <li><strong>en vs. ett</strong>: &bdquo;en&ldquo; f&uuml;r Maskulinum/Femininum, &bdquo;ett&ldquo; f&uuml;r Neutrum.</li>
+        <li><strong>sju vs. syv</strong>: beide korrekt f&uuml;r 7; &bdquo;syv&ldquo; ist informeller.</li>
+        <li><strong>Nicht mit D&auml;nisch verwechseln</strong>: Norwegisch verwendet regelm&auml;&szlig;ige Dezimalzehner (tjue, tretti&hellip;), kein Vigesimalsystem.</li>
+        <li><strong>&aring;tte vs. &aring;tti</strong>: 8 vs. 80 &mdash; ein Buchstabe Unterschied.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_no_en.html
+++ b/templates/learn_no_en.html
@@ -1,0 +1,139 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn Norwegian Numbers</h1>
+      <p>
+        This page covers <strong>Norwegian number words</strong> (Bokm&aring;l). Norwegian has regular tens
+        (unlike Danish), reversed word order for 21&ndash;99, and straightforward compound rules.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;12: irregular bases</a></li>
+        <li><a href="#teens">13&ndash;19: teens</a></li>
+        <li><a href="#tens">20&ndash;99: tens</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands &amp; large numbers</a></li>
+        <li><a href="#mistakes">Common mistakes</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;12: irregular bases</h2>
+      <p>Memorize these individually:</p>
+      <ul>
+        <li><strong>0</strong> = null</li>
+        <li><strong>1</strong> = en / ett</li>
+        <li><strong>2</strong> = to</li>
+        <li><strong>3</strong> = tre</li>
+        <li><strong>4</strong> = fire</li>
+        <li><strong>5</strong> = fem</li>
+        <li><strong>6</strong> = seks</li>
+        <li><strong>7</strong> = sju / syv</li>
+        <li><strong>8</strong> = &aring;tte</li>
+        <li><strong>9</strong> = ni</li>
+        <li><strong>10</strong> = ti</li>
+        <li><strong>11</strong> = elleve</li>
+        <li><strong>12</strong> = tolv</li>
+      </ul>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>13&ndash;19: teens</h2>
+      <p>
+        Pattern: digit + <strong>ten</strong> (from &ldquo;ti&rdquo;):
+      </p>
+      <ul>
+        <li><strong>13</strong> = tretten</li>
+        <li><strong>14</strong> = fjorten</li>
+        <li><strong>15</strong> = femten</li>
+        <li><strong>16</strong> = seksten</li>
+        <li><strong>17</strong> = sytten</li>
+        <li><strong>18</strong> = atten</li>
+        <li><strong>19</strong> = nitten</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: tens</h2>
+      <p>
+        Norwegian uses regular, decimal tens (unlike Danish&rsquo;s vigesimal system):
+      </p>
+      <ul>
+        <li><strong>20</strong> = tjue</li>
+        <li><strong>30</strong> = tretti</li>
+        <li><strong>40</strong> = f&oslash;rti</li>
+        <li><strong>50</strong> = femti</li>
+        <li><strong>60</strong> = seksti</li>
+        <li><strong>70</strong> = sytti</li>
+        <li><strong>80</strong> = &aring;tti</li>
+        <li><strong>90</strong> = nitti</li>
+      </ul>
+      <p>
+        Compounds: ones + <strong>og</strong> (&ldquo;and&rdquo;) + tens, or simply ones + tens as one word:
+      </p>
+      <ul>
+        <li><strong>21</strong> = tjueen</li>
+        <li><strong>35</strong> = trettifem</li>
+        <li><strong>99</strong> = nittini</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 22, 46, 83?</summary>
+        <p><strong>22</strong> tjueto &middot; <strong>46</strong> f&oslash;rtiseks &middot; <strong>83</strong> &aring;ttitre</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <ul>
+        <li><strong>100</strong> = (ett) hundre</li>
+        <li><strong>200</strong> = to hundre</li>
+        <li><strong>300</strong> = tre hundre</li>
+        <li><strong>150</strong> = (ett) hundre og femti</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands &amp; large numbers</h2>
+      <ul>
+        <li><strong>1,000</strong> = (ett) tusen</li>
+        <li><strong>2,000</strong> = to tusen</li>
+        <li><strong>10,000</strong> = ti tusen</li>
+        <li><strong>1,000,000</strong> = en million</li>
+        <li><strong>1,000,000,000</strong> = en milliard</li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Common mistakes</h2>
+      <ol>
+        <li><strong>en vs. ett</strong>: &ldquo;en&rdquo; for masculine/feminine, &ldquo;ett&rdquo; for neuter.</li>
+        <li><strong>sju vs. syv</strong>: both are correct for 7; &ldquo;syv&rdquo; is more informal.</li>
+        <li><strong>Don&rsquo;t confuse with Danish</strong>: Norwegian uses regular decimal tens (tjue, tretti&hellip;), not vigesimal.</li>
+        <li><strong>&aring;tte vs. &aring;tti</strong>: 8 vs. 80 &mdash; one letter difference.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_pt_de.html
+++ b/templates/learn_pt_de.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>Portugiesische Zahlen lernen</h1>
+      <p>
+        Diese Seite erkl&auml;rt <strong>portugiesische Zahlw&ouml;rter</strong> &mdash; die allgegenw&auml;rtige <em>e</em>-Konjunktion,
+        <em>cem</em> vs. <em>cento</em> und die Pluralhunderter wie <em>duzentos</em>.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;19: Grundbausteine</a></li>
+        <li><a href="#tens">20&ndash;99: Zehner</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender &amp; gro&szlig;e Zahlen</a></li>
+        <li><a href="#mistakes">Typische Fehler</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;19: Grundbausteine</h2>
+      <p>Einzeln auswendig lernen:</p>
+      <ul>
+        <li><strong>0</strong> = zero</li>
+        <li><strong>1</strong> = um</li>
+        <li><strong>2</strong> = dois</li>
+        <li><strong>3</strong> = tr&ecirc;s</li>
+        <li><strong>4</strong> = quatro</li>
+        <li><strong>5</strong> = cinco</li>
+        <li><strong>6</strong> = seis</li>
+        <li><strong>7</strong> = sete</li>
+        <li><strong>8</strong> = oito</li>
+        <li><strong>9</strong> = nove</li>
+        <li><strong>10</strong> = dez</li>
+        <li><strong>11</strong> = onze</li>
+        <li><strong>12</strong> = doze</li>
+        <li><strong>13</strong> = treze</li>
+        <li><strong>14</strong> = catorze (oder quatorze)</li>
+        <li><strong>15</strong> = quinze</li>
+        <li><strong>16</strong> = dezasseis (PT) / dezesseis (BR)</li>
+        <li><strong>17</strong> = dezassete (PT) / dezessete (BR)</li>
+        <li><strong>18</strong> = dezoito</li>
+        <li><strong>19</strong> = dezanove (PT) / dezenove (BR)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: Zehner</h2>
+      <p>
+        Die Zehner: vinte (20), trinta (30), quarenta (40), cinquenta (50), sessenta (60),
+        setenta (70), oitenta (80), noventa (90).
+      </p>
+      <p>
+        Verbindung mit <strong>e</strong> (&bdquo;und&ldquo;):
+      </p>
+      <ul>
+        <li><strong>21</strong> = vinte e um</li>
+        <li><strong>35</strong> = trinta e cinco</li>
+        <li><strong>99</strong> = noventa e nove</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 22, 47, 88?</summary>
+        <p><strong>22</strong> vinte e dois &middot; <strong>47</strong> quarenta e sete &middot; <strong>88</strong> oitenta e oito</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <ul>
+        <li><strong>100</strong> = cem (alleinstehend)</li>
+        <li><strong>101</strong> = cento e um (cento, wenn weitere Zahlen folgen)</li>
+        <li><strong>200</strong> = duzentos</li>
+        <li><strong>300</strong> = trezentos</li>
+        <li><strong>400</strong> = quatrocentos</li>
+        <li><strong>500</strong> = quinhentos</li>
+        <li><strong>600</strong> = seiscentos</li>
+        <li><strong>700</strong> = setecentos</li>
+        <li><strong>800</strong> = oitocentos</li>
+        <li><strong>900</strong> = novecentos</li>
+      </ul>
+      <p>
+        Wichtig: <strong>cem</strong> steht allein f&uuml;r genau 100; <strong>cento</strong> wird verwendet, wenn weitere Ziffern folgen (cento e um, cento e vinte).
+        Die <strong>e</strong>-Konjunktion wird durchgehend verwendet.
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender &amp; gro&szlig;e Zahlen</h2>
+      <ul>
+        <li><strong>1.000</strong> = mil</li>
+        <li><strong>2.000</strong> = dois mil</li>
+        <li><strong>1.500</strong> = mil e quinhentos</li>
+        <li><strong>1.000.000</strong> = um milh&atilde;o</li>
+        <li><strong>2.000.000</strong> = dois milh&otilde;es</li>
+        <li><strong>1.000.000.000</strong> = um bilh&atilde;o (BR) / mil milh&otilde;es (PT)</li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Typische Fehler</h2>
+      <ol>
+        <li><strong>cem vs. cento</strong>: 100 = cem, aber 101 = cento e um.</li>
+        <li><strong>Pluralhunderter</strong>: duzentos, trezentos (nicht &bdquo;dois centos&ldquo;).</li>
+        <li><strong>quinhentos</strong> (500): unregelm&auml;&szlig;ig (nicht &bdquo;cincocentos&ldquo;).</li>
+        <li><strong>e</strong>-Konjunktion: wird &uuml;berall zwischen den Bestandteilen verwendet.</li>
+        <li><strong>mil</strong>: nie &bdquo;um mil&ldquo; f&uuml;r 1.000.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_pt_en.html
+++ b/templates/learn_pt_en.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn Portuguese Numbers</h1>
+      <p>
+        This page covers <strong>Portuguese number words</strong> &mdash; the <em>e</em> conjunction everywhere,
+        <em>cem</em> vs. <em>cento</em>, and plural hundreds like <em>duzentos</em>.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;19: building blocks</a></li>
+        <li><a href="#tens">20&ndash;99: tens</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands &amp; large numbers</a></li>
+        <li><a href="#mistakes">Common mistakes</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;19: building blocks</h2>
+      <p>Memorize individually:</p>
+      <ul>
+        <li><strong>0</strong> = zero</li>
+        <li><strong>1</strong> = um</li>
+        <li><strong>2</strong> = dois</li>
+        <li><strong>3</strong> = tr&ecirc;s</li>
+        <li><strong>4</strong> = quatro</li>
+        <li><strong>5</strong> = cinco</li>
+        <li><strong>6</strong> = seis</li>
+        <li><strong>7</strong> = sete</li>
+        <li><strong>8</strong> = oito</li>
+        <li><strong>9</strong> = nove</li>
+        <li><strong>10</strong> = dez</li>
+        <li><strong>11</strong> = onze</li>
+        <li><strong>12</strong> = doze</li>
+        <li><strong>13</strong> = treze</li>
+        <li><strong>14</strong> = catorze (or quatorze)</li>
+        <li><strong>15</strong> = quinze</li>
+        <li><strong>16</strong> = dezasseis (PT) / dezesseis (BR)</li>
+        <li><strong>17</strong> = dezassete (PT) / dezessete (BR)</li>
+        <li><strong>18</strong> = dezoito</li>
+        <li><strong>19</strong> = dezanove (PT) / dezenove (BR)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: tens</h2>
+      <p>
+        The tens: vinte (20), trinta (30), quarenta (40), cinquenta (50), sessenta (60),
+        setenta (70), oitenta (80), noventa (90).
+      </p>
+      <p>
+        Combine with <strong>e</strong> (&ldquo;and&rdquo;):
+      </p>
+      <ul>
+        <li><strong>21</strong> = vinte e um</li>
+        <li><strong>35</strong> = trinta e cinco</li>
+        <li><strong>99</strong> = noventa e nove</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 22, 47, 88?</summary>
+        <p><strong>22</strong> vinte e dois &middot; <strong>47</strong> quarenta e sete &middot; <strong>88</strong> oitenta e oito</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <ul>
+        <li><strong>100</strong> = cem (when alone)</li>
+        <li><strong>101</strong> = cento e um (cento when followed by more)</li>
+        <li><strong>200</strong> = duzentos</li>
+        <li><strong>300</strong> = trezentos</li>
+        <li><strong>400</strong> = quatrocentos</li>
+        <li><strong>500</strong> = quinhentos</li>
+        <li><strong>600</strong> = seiscentos</li>
+        <li><strong>700</strong> = setecentos</li>
+        <li><strong>800</strong> = oitocentos</li>
+        <li><strong>900</strong> = novecentos</li>
+      </ul>
+      <p>
+        Key: <strong>cem</strong> stands alone for exactly 100; use <strong>cento</strong> when followed by other digits (cento e um, cento e vinte).
+        The <strong>e</strong> conjunction is used throughout.
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands &amp; large numbers</h2>
+      <ul>
+        <li><strong>1,000</strong> = mil</li>
+        <li><strong>2,000</strong> = dois mil</li>
+        <li><strong>1,500</strong> = mil e quinhentos</li>
+        <li><strong>1,000,000</strong> = um milh&atilde;o</li>
+        <li><strong>2,000,000</strong> = dois milh&otilde;es</li>
+        <li><strong>1,000,000,000</strong> = um bilh&atilde;o (BR) / mil milh&otilde;es (PT)</li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Common mistakes</h2>
+      <ol>
+        <li><strong>cem vs. cento</strong>: 100 = cem, but 101 = cento e um.</li>
+        <li><strong>Plural hundreds</strong>: duzentos, trezentos (not &ldquo;dois centos&rdquo;).</li>
+        <li><strong>quinhentos</strong> (500): irregular (not &ldquo;cincocentos&rdquo;).</li>
+        <li><strong>e</strong> conjunction: used everywhere between components.</li>
+        <li><strong>mil</strong>: never &ldquo;um mil&rdquo; for 1,000.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_sv_de.html
+++ b/templates/learn_sv_de.html
@@ -1,0 +1,130 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>Schwedische Zahlen lernen</h1>
+      <p>
+        Diese Seite erkl&auml;rt <strong>schwedische Zahlw&ouml;rter</strong> &mdash; unregelm&auml;&szlig;ige Grundzahlen, das <em>-ton</em>-Suffix f&uuml;r Teens,
+        zusammengesetzte W&ouml;rter und Sonderzeichen (&aring;, &auml;, &ouml;).
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;12: unregelm&auml;&szlig;ige Grundzahlen</a></li>
+        <li><a href="#teens">13&ndash;19: -ton-Suffix</a></li>
+        <li><a href="#tens">20&ndash;99: Zehner</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender &amp; gro&szlig;e Zahlen</a></li>
+        <li><a href="#mistakes">Typische Fehler</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;12: unregelm&auml;&szlig;ige Grundzahlen</h2>
+      <p>Einzeln auswendig lernen:</p>
+      <ul>
+        <li><strong>0</strong> = noll</li>
+        <li><strong>1</strong> = en / ett</li>
+        <li><strong>2</strong> = tv&aring;</li>
+        <li><strong>3</strong> = tre</li>
+        <li><strong>4</strong> = fyra</li>
+        <li><strong>5</strong> = fem</li>
+        <li><strong>6</strong> = sex</li>
+        <li><strong>7</strong> = sju</li>
+        <li><strong>8</strong> = &aring;tta</li>
+        <li><strong>9</strong> = nio</li>
+        <li><strong>10</strong> = tio</li>
+        <li><strong>11</strong> = elva</li>
+        <li><strong>12</strong> = tolv</li>
+      </ul>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>13&ndash;19: -ton-Suffix</h2>
+      <p>
+        Muster: Ziffer + <strong>ton</strong> (von &bdquo;tio&ldquo;, also zehn):
+      </p>
+      <ul>
+        <li><strong>13</strong> = tretton</li>
+        <li><strong>14</strong> = fjorton</li>
+        <li><strong>15</strong> = femton</li>
+        <li><strong>16</strong> = sexton</li>
+        <li><strong>17</strong> = sjutton</li>
+        <li><strong>18</strong> = arton</li>
+        <li><strong>19</strong> = nitton</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: Zehner</h2>
+      <p>
+        Die Zehnerw&ouml;rter: tjugo (20), trettio (30), fyrtio (40), femtio (50), sextio (60),
+        sjuttio (70), &aring;ttio (80), nittio (90).
+      </p>
+      <ul>
+        <li><strong>21</strong> = tjugoen</li>
+        <li><strong>35</strong> = trettiofem</li>
+        <li><strong>99</strong> = nittionio</li>
+      </ul>
+      <p>
+        Zahlen von 21&ndash;99 werden typischerweise als ein Wort geschrieben.
+      </p>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 22, 48, 73?</summary>
+        <p><strong>22</strong> tjugotv&aring; &middot; <strong>48</strong> fyrtio&aring;tta &middot; <strong>73</strong> sjuttiotre</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <ul>
+        <li><strong>100</strong> = (ett) hundra</li>
+        <li><strong>200</strong> = tv&aring;hundra</li>
+        <li><strong>300</strong> = trehundra</li>
+        <li><strong>123</strong> = (ett)hundratjugotre</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender &amp; gro&szlig;e Zahlen</h2>
+      <ul>
+        <li><strong>1.000</strong> = (ett) tusen</li>
+        <li><strong>2.000</strong> = tv&aring;tusen</li>
+        <li><strong>10.000</strong> = tiotusen</li>
+        <li><strong>1.000.000</strong> = en miljon</li>
+        <li><strong>1.000.000.000</strong> = en miljard</li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Typische Fehler</h2>
+      <ol>
+        <li><strong>en vs. ett</strong>: &bdquo;en&ldquo; f&uuml;r en-W&ouml;rter, &bdquo;ett&ldquo; f&uuml;r ett-W&ouml;rter; bei alleinstehenden Zahlen ist &bdquo;en&ldquo; &uuml;blich.</li>
+        <li><strong>Teens-Schreibweise</strong>: fjorton (14), arton (18) &mdash; nicht direkt vom Ziffernamen.</li>
+        <li><strong>Zusammensetzungen</strong>: tjugoen, trettiofem &mdash; keine Leerzeichen zwischen Zehnern und Einern.</li>
+        <li><strong>Sonderzeichen</strong>: &aring; (&aring;tta, &aring;ttio), &ouml;, &auml; in manchen Formen.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_sv_en.html
+++ b/templates/learn_sv_en.html
@@ -1,0 +1,130 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn Swedish Numbers</h1>
+      <p>
+        This page covers <strong>Swedish number words</strong> &mdash; irregular bases, the <em>-ton</em> suffix for teens,
+        compound words, and special characters (&aring;, &auml;, &ouml;).
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#basics">0&ndash;12: irregular bases</a></li>
+        <li><a href="#teens">13&ndash;19: -ton suffix</a></li>
+        <li><a href="#tens">20&ndash;99: tens</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands &amp; large numbers</a></li>
+        <li><a href="#mistakes">Common mistakes</a></li>
+      </ul>
+    </nav>
+
+    <section id="basics" class="learn-section">
+      <h2>0&ndash;12: irregular bases</h2>
+      <p>Memorize these individually:</p>
+      <ul>
+        <li><strong>0</strong> = noll</li>
+        <li><strong>1</strong> = en / ett</li>
+        <li><strong>2</strong> = tv&aring;</li>
+        <li><strong>3</strong> = tre</li>
+        <li><strong>4</strong> = fyra</li>
+        <li><strong>5</strong> = fem</li>
+        <li><strong>6</strong> = sex</li>
+        <li><strong>7</strong> = sju</li>
+        <li><strong>8</strong> = &aring;tta</li>
+        <li><strong>9</strong> = nio</li>
+        <li><strong>10</strong> = tio</li>
+        <li><strong>11</strong> = elva</li>
+        <li><strong>12</strong> = tolv</li>
+      </ul>
+    </section>
+
+    <section id="teens" class="learn-section">
+      <h2>13&ndash;19: -ton suffix</h2>
+      <p>
+        Pattern: digit + <strong>ton</strong> (from &ldquo;tio&rdquo;, meaning ten):
+      </p>
+      <ul>
+        <li><strong>13</strong> = tretton</li>
+        <li><strong>14</strong> = fjorton</li>
+        <li><strong>15</strong> = femton</li>
+        <li><strong>16</strong> = sexton</li>
+        <li><strong>17</strong> = sjutton</li>
+        <li><strong>18</strong> = arton</li>
+        <li><strong>19</strong> = nitton</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>20&ndash;99: tens</h2>
+      <p>
+        The tens words: tjugo (20), trettio (30), fyrtio (40), femtio (50), sextio (60),
+        sjuttio (70), &aring;ttio (80), nittio (90).
+      </p>
+      <ul>
+        <li><strong>21</strong> = tjugoen</li>
+        <li><strong>35</strong> = trettiofem</li>
+        <li><strong>99</strong> = nittionio</li>
+      </ul>
+      <p>
+        Numbers 21&ndash;99 are typically written as one word (compound).
+      </p>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 22, 48, 73?</summary>
+        <p><strong>22</strong> tjugotv&aring; &middot; <strong>48</strong> fyrtio&aring;tta &middot; <strong>73</strong> sjuttiotre</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <ul>
+        <li><strong>100</strong> = (ett) hundra</li>
+        <li><strong>200</strong> = tv&aring;hundra</li>
+        <li><strong>300</strong> = trehundra</li>
+        <li><strong>123</strong> = (ett)hundratjugotre</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands &amp; large numbers</h2>
+      <ul>
+        <li><strong>1,000</strong> = (ett) tusen</li>
+        <li><strong>2,000</strong> = tv&aring;tusen</li>
+        <li><strong>10,000</strong> = tiotusen</li>
+        <li><strong>1,000,000</strong> = en miljon</li>
+        <li><strong>1,000,000,000</strong> = en miljard</li>
+      </ul>
+    </section>
+
+    <section id="mistakes" class="learn-section">
+      <h2>Common mistakes</h2>
+      <ol>
+        <li><strong>en vs. ett</strong>: &ldquo;en&rdquo; for en-words, &ldquo;ett&rdquo; for ett-words; for standalone numbers &ldquo;en&rdquo; is typical.</li>
+        <li><strong>Teens spelling</strong>: fjorton (14), arton (18) &mdash; not directly from the digit name.</li>
+        <li><strong>Compound words</strong>: tjugoen, trettiofem &mdash; no spaces between tens and ones.</li>
+        <li><strong>Special characters</strong>: &aring; (&aring;tta, &aring;ttio), &ouml;, &auml; in some forms.</li>
+      </ol>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_tr_de.html
+++ b/templates/learn_tr_de.html
@@ -1,0 +1,120 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>T&uuml;rkische Zahlen lernen</h1>
+      <p>
+        Diese Seite erkl&auml;rt <strong>t&uuml;rkische Zahlw&ouml;rter</strong>. T&uuml;rkische Zahlen sind bemerkenswert regelm&auml;&szlig;ig &mdash;
+        keine unregelm&auml;&szlig;igen Teens oder Zusammensetzungstricks. Lerne die Grundw&ouml;rter und du kannst jede Zahl bilden.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#digits">Ziffern: 0&ndash;9</a></li>
+        <li><a href="#tens">10&ndash;99: Zehner</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender &amp; gro&szlig;e Zahlen</a></li>
+        <li><a href="#spelling">Schreibweise &amp; Sonderzeichen</a></li>
+      </ul>
+    </nav>
+
+    <section id="digits" class="learn-section">
+      <h2>Ziffern: 0&ndash;9</h2>
+      <ul>
+        <li><strong>0</strong> = s&iacute;f&iacute;r</li>
+        <li><strong>1</strong> = bir</li>
+        <li><strong>2</strong> = iki</li>
+        <li><strong>3</strong> = &uuml;&ccedil;</li>
+        <li><strong>4</strong> = d&ouml;rt</li>
+        <li><strong>5</strong> = be&scedil;</li>
+        <li><strong>6</strong> = alt&inodot;</li>
+        <li><strong>7</strong> = yedi</li>
+        <li><strong>8</strong> = sekiz</li>
+        <li><strong>9</strong> = dokuz</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>10&ndash;99: Zehner</h2>
+      <p>
+        Einfach das Zehnerwort, dann den Einer (mit Leerzeichen). Keine Konjunktionen n&ouml;tig:
+      </p>
+      <ul>
+        <li><strong>10</strong> = on</li>
+        <li><strong>11</strong> = on bir</li>
+        <li><strong>20</strong> = yirmi</li>
+        <li><strong>30</strong> = otuz</li>
+        <li><strong>40</strong> = k&inodot;rk</li>
+        <li><strong>50</strong> = elli</li>
+        <li><strong>60</strong> = altm&inodot;&scedil;</li>
+        <li><strong>70</strong> = yetmi&scedil;</li>
+        <li><strong>80</strong> = seksen</li>
+        <li><strong>90</strong> = doksan</li>
+        <li><strong>42</strong> = k&inodot;rk iki</li>
+        <li><strong>99</strong> = doksan dokuz</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 15, 37, 84?</summary>
+        <p><strong>15</strong> on be&scedil; &middot; <strong>37</strong> otuz yedi &middot; <strong>84</strong> seksen d&ouml;rt</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <ul>
+        <li><strong>100</strong> = y&uuml;z</li>
+        <li><strong>200</strong> = iki y&uuml;z</li>
+        <li><strong>300</strong> = &uuml;&ccedil; y&uuml;z</li>
+        <li><strong>150</strong> = y&uuml;z elli</li>
+        <li><strong>999</strong> = dokuz y&uuml;z doksan dokuz</li>
+      </ul>
+      <p>
+        Beachte: 100 ist einfach <strong>y&uuml;z</strong> (nicht &bdquo;bir y&uuml;z&ldquo;).
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender &amp; gro&szlig;e Zahlen</h2>
+      <ul>
+        <li><strong>1.000</strong> = bin (nicht &bdquo;bir bin&ldquo;)</li>
+        <li><strong>2.000</strong> = iki bin</li>
+        <li><strong>10.000</strong> = on bin</li>
+        <li><strong>1.000.000</strong> = bir milyon</li>
+        <li><strong>1.000.000.000</strong> = bir milyar</li>
+      </ul>
+    </section>
+
+    <section id="spelling" class="learn-section">
+      <h2>Schreibweise &amp; Sonderzeichen</h2>
+      <p>T&uuml;rkisch verwendet einige Sonderzeichen:</p>
+      <ul>
+        <li><strong>&ccedil;</strong> &mdash; wie in &uuml;&ccedil; (3)</li>
+        <li><strong>&scedil;</strong> &mdash; wie in be&scedil; (5)</li>
+        <li><strong>&uuml;</strong> &mdash; wie in &uuml;&ccedil; (3), y&uuml;z (100)</li>
+        <li><strong>&ouml;</strong> &mdash; wie in d&ouml;rt (4)</li>
+        <li><strong>&inodot;</strong> (i ohne Punkt) &mdash; wie in k&inodot;rk (40), alt&inodot; (6)</li>
+      </ul>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_tr_en.html
+++ b/templates/learn_tr_en.html
@@ -1,0 +1,120 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn Turkish Numbers</h1>
+      <p>
+        This page covers <strong>Turkish number words</strong>. Turkish numbers are remarkably regular &mdash;
+        there are no irregular teens or compound-word tricks. Learn the base words and you can build any number.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#digits">Digits: 0&ndash;9</a></li>
+        <li><a href="#tens">10&ndash;99: tens</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands &amp; large numbers</a></li>
+        <li><a href="#spelling">Spelling &amp; special characters</a></li>
+      </ul>
+    </nav>
+
+    <section id="digits" class="learn-section">
+      <h2>Digits: 0&ndash;9</h2>
+      <ul>
+        <li><strong>0</strong> = s&iacute;f&iacute;r</li>
+        <li><strong>1</strong> = bir</li>
+        <li><strong>2</strong> = iki</li>
+        <li><strong>3</strong> = &uuml;&ccedil;</li>
+        <li><strong>4</strong> = d&ouml;rt</li>
+        <li><strong>5</strong> = be&scedil;</li>
+        <li><strong>6</strong> = alt&inodot;</li>
+        <li><strong>7</strong> = yedi</li>
+        <li><strong>8</strong> = sekiz</li>
+        <li><strong>9</strong> = dokuz</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>10&ndash;99: tens</h2>
+      <p>
+        Simply say the tens word, then the ones word (with a space). No conjunctions needed:
+      </p>
+      <ul>
+        <li><strong>10</strong> = on</li>
+        <li><strong>11</strong> = on bir</li>
+        <li><strong>20</strong> = yirmi</li>
+        <li><strong>30</strong> = otuz</li>
+        <li><strong>40</strong> = k&inodot;rk</li>
+        <li><strong>50</strong> = elli</li>
+        <li><strong>60</strong> = altm&inodot;&scedil;</li>
+        <li><strong>70</strong> = yetmi&scedil;</li>
+        <li><strong>80</strong> = seksen</li>
+        <li><strong>90</strong> = doksan</li>
+        <li><strong>42</strong> = k&inodot;rk iki</li>
+        <li><strong>99</strong> = doksan dokuz</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 15, 37, 84?</summary>
+        <p><strong>15</strong> on be&scedil; &middot; <strong>37</strong> otuz yedi &middot; <strong>84</strong> seksen d&ouml;rt</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <ul>
+        <li><strong>100</strong> = y&uuml;z</li>
+        <li><strong>200</strong> = iki y&uuml;z</li>
+        <li><strong>300</strong> = &uuml;&ccedil; y&uuml;z</li>
+        <li><strong>150</strong> = y&uuml;z elli</li>
+        <li><strong>999</strong> = dokuz y&uuml;z doksan dokuz</li>
+      </ul>
+      <p>
+        Note: 100 is just <strong>y&uuml;z</strong> (not &ldquo;bir y&uuml;z&rdquo;).
+      </p>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands &amp; large numbers</h2>
+      <ul>
+        <li><strong>1,000</strong> = bin (not &ldquo;bir bin&rdquo;)</li>
+        <li><strong>2,000</strong> = iki bin</li>
+        <li><strong>10,000</strong> = on bin</li>
+        <li><strong>1,000,000</strong> = bir milyon</li>
+        <li><strong>1,000,000,000</strong> = bir milyar</li>
+      </ul>
+    </section>
+
+    <section id="spelling" class="learn-section">
+      <h2>Spelling &amp; special characters</h2>
+      <p>Turkish uses some characters not found in English:</p>
+      <ul>
+        <li><strong>&ccedil;</strong> &mdash; as in &uuml;&ccedil; (3)</li>
+        <li><strong>&scedil;</strong> &mdash; as in be&scedil; (5)</li>
+        <li><strong>&uuml;</strong> &mdash; as in &uuml;&ccedil; (3), y&uuml;z (100)</li>
+        <li><strong>&ouml;</strong> &mdash; as in d&ouml;rt (4)</li>
+        <li><strong>&inodot;</strong> (dotless i) &mdash; as in k&inodot;rk (40), alt&inodot; (6)</li>
+      </ul>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_zh_de.html
+++ b/templates/learn_zh_de.html
@@ -1,0 +1,130 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Zur&uuml;ck</a>
+
+    <header class="learn-hero">
+      <h1>Chinesische Zahlen lernen</h1>
+      <p>
+        Diese Seite behandelt <strong>chinesische (Mandarin) Zahlw&ouml;rter</strong> &mdash; ein regelm&auml;&szlig;iges Stellenwertsystem
+        mit Ziffern und Stellenwertzeichen. Die gr&ouml;&szlig;te Herausforderung ist, wann <strong>&#38646;</strong> (Null) als L&uuml;ckenf&uuml;ller verwendet wird.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Inhalt</strong>
+      <ul>
+        <li><a href="#digits">Ziffern: 0&ndash;9</a></li>
+        <li><a href="#tens">10&ndash;99: Zehner</a></li>
+        <li><a href="#hundreds">Hunderter</a></li>
+        <li><a href="#thousands">Tausender</a></li>
+        <li><a href="#large">Gro&szlig;e Zahlen: &#19975; (10.000+)</a></li>
+        <li><a href="#zero">Die Null-Regeln (&#38646;)</a></li>
+      </ul>
+    </nav>
+
+    <section id="digits" class="learn-section">
+      <h2>Ziffern: 0&ndash;9</h2>
+      <ul>
+        <li><strong>0</strong> = &#38646; (l&iacute;ng)</li>
+        <li><strong>1</strong> = &#19968; (y&imacr;)</li>
+        <li><strong>2</strong> = &#20108; (&egrave;r)</li>
+        <li><strong>3</strong> = &#19977; (s&amacr;n)</li>
+        <li><strong>4</strong> = &#22235; (s&igrave;)</li>
+        <li><strong>5</strong> = &#20116; (w&#468;)</li>
+        <li><strong>6</strong> = &#20845; (li&ugrave;)</li>
+        <li><strong>7</strong> = &#19971; (q&imacr;)</li>
+        <li><strong>8</strong> = &#20843; (b&amacr;)</li>
+        <li><strong>9</strong> = &#20061; (ji&#468;)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>10&ndash;99: Zehner</h2>
+      <p>
+        <strong>&#21313;</strong> (sh&iacute;) bedeutet 10. Ziffer + &#21313; f&uuml;r Vielfache von zehn, &#21313; + Ziffer f&uuml;r 11&ndash;19:
+      </p>
+      <ul>
+        <li><strong>10</strong> = &#21313;</li>
+        <li><strong>11</strong> = &#21313;&#19968;</li>
+        <li><strong>20</strong> = &#20108;&#21313;</li>
+        <li><strong>25</strong> = &#20108;&#21313;&#20116;</li>
+        <li><strong>99</strong> = &#20061;&#21313;&#20061;</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Mini-Check</strong>: 14, 30, 67?</summary>
+        <p><strong>14</strong> &#21313;&#22235; &middot; <strong>30</strong> &#19977;&#21313; &middot; <strong>67</strong> &#20845;&#21313;&#19971;</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hunderter</h2>
+      <p>
+        <strong>&#30334;</strong> (b&#462;i) bedeutet 100:
+      </p>
+      <ul>
+        <li><strong>100</strong> = &#19968;&#30334;</li>
+        <li><strong>200</strong> = &#20108;&#30334;</li>
+        <li><strong>350</strong> = &#19977;&#30334;&#20116;&#21313;</li>
+        <li><strong>101</strong> = &#19968;&#30334;&#38646;&#19968; (&#38646; markiert die L&uuml;cke)</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Tausender</h2>
+      <p>
+        <strong>&#21315;</strong> (qi&amacr;n) bedeutet 1.000:
+      </p>
+      <ul>
+        <li><strong>1.000</strong> = &#19968;&#21315;</li>
+        <li><strong>2.000</strong> = &#20108;&#21315;</li>
+        <li><strong>5.678</strong> = &#20116;&#21315;&#20845;&#30334;&#19971;&#21313;&#20843;</li>
+        <li><strong>1.001</strong> = &#19968;&#21315;&#38646;&#19968;</li>
+      </ul>
+    </section>
+
+    <section id="large" class="learn-section">
+      <h2>Gro&szlig;e Zahlen: &#19975; (10.000+)</h2>
+      <p>
+        Chinesisch gruppiert Zahlen in Einheiten von <strong>10.000</strong> (&#19975;, w&agrave;n):
+      </p>
+      <ul>
+        <li><strong>10.000</strong> = &#19968;&#19975;</li>
+        <li><strong>100.000</strong> = &#21313;&#19975;</li>
+        <li><strong>1.000.000</strong> = &#30334;&#19975;</li>
+      </ul>
+    </section>
+
+    <section id="zero" class="learn-section">
+      <h2>Die Null-Regeln (&#38646;)</h2>
+      <p>
+        &#38646; wird als Platzhalter eingef&uuml;gt, wenn eine L&uuml;cke zwischen Stellenwerten besteht:
+      </p>
+      <ol>
+        <li><strong>101</strong> = &#19968;&#30334;<strong>&#38646;</strong>&#19968; (L&uuml;cke bei den Zehnern)</li>
+        <li><strong>1.001</strong> = &#19968;&#21315;<strong>&#38646;</strong>&#19968; (L&uuml;cke bei Hundertern und Zehnern)</li>
+        <li><strong>1.010</strong> = &#19968;&#21315;<strong>&#38646;</strong>&#19968;&#21313;</li>
+      </ol>
+      <p>
+        Mehrere aufeinanderfolgende Nullen werden durch ein <strong>einziges</strong> &#38646; dargestellt.
+      </p>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Zum Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/learn_zh_en.html
+++ b/templates/learn_zh_en.html
@@ -1,0 +1,130 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block meta_description %}<meta name="description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block og_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block og_description %}<meta property="og:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+{% block twitter_title %}{{ get_text('seo_title_learn') }}{% endblock %}
+{% block twitter_description %}<meta name="twitter:description" content="{{ get_text('meta_desc_learn') }}">{% endblock %}
+
+{% block content %}
+<main class="container learn">
+  <div class="learn-content">
+    <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn-back">&larr; Back</a>
+
+    <header class="learn-hero">
+      <h1>Learn Chinese Numbers</h1>
+      <p>
+        This page covers <strong>Chinese (Mandarin) number words</strong> &mdash; a regular positional system
+        with digits and place value characters. The key challenge is knowing when to use <strong>&#38646;</strong> (zero) as a gap marker.
+      </p>
+    </header>
+
+    <nav class="learn-toc">
+      <strong>Contents</strong>
+      <ul>
+        <li><a href="#digits">Digits: 0&ndash;9</a></li>
+        <li><a href="#tens">10&ndash;99: tens</a></li>
+        <li><a href="#hundreds">Hundreds</a></li>
+        <li><a href="#thousands">Thousands</a></li>
+        <li><a href="#large">Large numbers: &#19975; (10,000+)</a></li>
+        <li><a href="#zero">The zero (&#38646;) rules</a></li>
+      </ul>
+    </nav>
+
+    <section id="digits" class="learn-section">
+      <h2>Digits: 0&ndash;9</h2>
+      <ul>
+        <li><strong>0</strong> = &#38646; (l&iacute;ng)</li>
+        <li><strong>1</strong> = &#19968; (y&imacr;)</li>
+        <li><strong>2</strong> = &#20108; (&egrave;r)</li>
+        <li><strong>3</strong> = &#19977; (s&amacr;n)</li>
+        <li><strong>4</strong> = &#22235; (s&igrave;)</li>
+        <li><strong>5</strong> = &#20116; (w&#468;)</li>
+        <li><strong>6</strong> = &#20845; (li&ugrave;)</li>
+        <li><strong>7</strong> = &#19971; (q&imacr;)</li>
+        <li><strong>8</strong> = &#20843; (b&amacr;)</li>
+        <li><strong>9</strong> = &#20061; (ji&#468;)</li>
+      </ul>
+    </section>
+
+    <section id="tens" class="learn-section">
+      <h2>10&ndash;99: tens</h2>
+      <p>
+        <strong>&#21313;</strong> (sh&iacute;) means 10. The pattern is digit + &#21313; for multiples of ten, &#21313; + digit for teens:
+      </p>
+      <ul>
+        <li><strong>10</strong> = &#21313;</li>
+        <li><strong>11</strong> = &#21313;&#19968;</li>
+        <li><strong>20</strong> = &#20108;&#21313;</li>
+        <li><strong>25</strong> = &#20108;&#21313;&#20116;</li>
+        <li><strong>99</strong> = &#20061;&#21313;&#20061;</li>
+      </ul>
+
+      <details class="learn-check">
+        <summary><strong>Quick check</strong>: 14, 30, 67?</summary>
+        <p><strong>14</strong> &#21313;&#22235; &middot; <strong>30</strong> &#19977;&#21313; &middot; <strong>67</strong> &#20845;&#21313;&#19971;</p>
+      </details>
+    </section>
+
+    <section id="hundreds" class="learn-section">
+      <h2>Hundreds</h2>
+      <p>
+        <strong>&#30334;</strong> (b&#462;i) means 100:
+      </p>
+      <ul>
+        <li><strong>100</strong> = &#19968;&#30334;</li>
+        <li><strong>200</strong> = &#20108;&#30334;</li>
+        <li><strong>350</strong> = &#19977;&#30334;&#20116;&#21313;</li>
+        <li><strong>101</strong> = &#19968;&#30334;&#38646;&#19968; (&#38646; marks the gap)</li>
+      </ul>
+    </section>
+
+    <section id="thousands" class="learn-section">
+      <h2>Thousands</h2>
+      <p>
+        <strong>&#21315;</strong> (qi&amacr;n) means 1,000:
+      </p>
+      <ul>
+        <li><strong>1,000</strong> = &#19968;&#21315;</li>
+        <li><strong>2,000</strong> = &#20108;&#21315;</li>
+        <li><strong>5,678</strong> = &#20116;&#21315;&#20845;&#30334;&#19971;&#21313;&#20843;</li>
+        <li><strong>1,001</strong> = &#19968;&#21315;&#38646;&#19968;</li>
+      </ul>
+    </section>
+
+    <section id="large" class="learn-section">
+      <h2>Large numbers: &#19975; (10,000+)</h2>
+      <p>
+        Chinese groups numbers in units of <strong>10,000</strong> (&#19975;, w&agrave;n):
+      </p>
+      <ul>
+        <li><strong>10,000</strong> = &#19968;&#19975;</li>
+        <li><strong>100,000</strong> = &#21313;&#19975;</li>
+        <li><strong>1,000,000</strong> = &#30334;&#19975;</li>
+      </ul>
+    </section>
+
+    <section id="zero" class="learn-section">
+      <h2>The zero (&#38646;) rules</h2>
+      <p>
+        &#38646; is inserted as a placeholder when there is a gap between place values:
+      </p>
+      <ol>
+        <li><strong>101</strong> = &#19968;&#30334;<strong>&#38646;</strong>&#19968; (gap where tens would be)</li>
+        <li><strong>1,001</strong> = &#19968;&#21315;<strong>&#38646;</strong>&#19968; (gap where hundreds and tens would be)</li>
+        <li><strong>1,010</strong> = &#19968;&#21315;<strong>&#38646;</strong>&#19968;&#21313;</li>
+      </ol>
+      <p>
+        Multiple consecutive zeros are represented by a <strong>single</strong> &#38646;.
+      </p>
+    </section>
+
+    <div class="learn-footer">
+      <a href="{{ url_for('mode_selection', lang_code=lang_code) }}" class="btn btn-primary">
+        Start Quiz
+      </a>
+    </div>
+  </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
Add learn pages (EN + DE UI) for French, Japanese, German, Korean, Italian, Chinese, Portuguese, Turkish, Swedish, Danish, and Norwegian. Update app.py to enable learn routes, learn buttons, and sitemap entries for all 12 languages (including existing Spanish). Closes #61