### PR TITLE
Optimize app for mobile with touch-friendly interactions

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -32,6 +32,12 @@
     box-sizing: border-box;
 }
 
+/* Touch interaction improvements */
+button, .btn, .option-btn, a.btn, .cookie-accept-btn, .mode-card, .learn-card {
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+}
+
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, 'Noto Sans Devanagari', sans-serif;
     background: linear-gradient(135deg, #F2F3AE 0%, #EDD382 100%);
@@ -57,11 +63,17 @@ body {
     box-shadow: 0 2px 8px rgba(0,0,0,0.08);
     transition: all 0.2s ease; padding: 0;
 }
-.lang-globe-btn:hover {
+@media (hover: hover) {
+    .lang-globe-btn:hover {
+        background: rgba(255,255,255,0.9);
+        border-color: rgba(252,158,79,0.5);
+        box-shadow: 0 4px 12px rgba(252,158,79,0.2);
+        transform: translateY(-1px);
+    }
+}
+.lang-globe-btn:active {
     background: rgba(255,255,255,0.9);
     border-color: rgba(252,158,79,0.5);
-    box-shadow: 0 4px 12px rgba(252,158,79,0.2);
-    transform: translateY(-1px);
 }
 
 .lang-dropdown {
@@ -108,6 +120,17 @@ body {
     width: 100%;
     max-width: 900px;
     padding: 20px;
+}
+
+/* Back Navigation */
+.back-nav {
+    text-align: left;
+    margin-bottom: 1rem;
+}
+
+.btn-back-nav {
+    display: inline-block;
+    padding: 0.5rem 1rem;
 }
 
 /* Landing Page */
@@ -266,11 +289,17 @@ body {
     box-shadow: 0 4px 15px rgba(2, 1, 34, 0.08);
 }
 
-.mode-card:not(.mode-disabled):hover {
+@media (hover: hover) {
+    .mode-card:not(.mode-disabled):hover {
+        background: linear-gradient(135deg, #EDD382 0%, #FC9E4F 100%);
+        border-color: #FC9E4F;
+        transform: translateY(-5px);
+        box-shadow: 0 15px 40px rgba(252, 158, 79, 0.4), 0 0 20px rgba(252, 158, 79, 0.2);
+    }
+}
+.mode-card:not(.mode-disabled):active {
     background: linear-gradient(135deg, #EDD382 0%, #FC9E4F 100%);
     border-color: #FC9E4F;
-    transform: translateY(-5px);
-    box-shadow: 0 15px 40px rgba(252, 158, 79, 0.4), 0 0 20px rgba(252, 158, 79, 0.2);
 }
 
 .mode-disabled {
@@ -365,9 +394,14 @@ body {
     box-shadow: 0 4px 15px rgba(252, 158, 79, 0.3);
 }
 
-.btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 10px 30px rgba(252, 158, 79, 0.5), 0 0 20px rgba(252, 158, 79, 0.3);
+@media (hover: hover) {
+    .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 10px 30px rgba(252, 158, 79, 0.5), 0 0 20px rgba(252, 158, 79, 0.3);
+        background: linear-gradient(135deg, #654F6F 0%, #FC9E4F 100%);
+    }
+}
+.btn-primary:active {
     background: linear-gradient(135deg, #654F6F 0%, #FC9E4F 100%);
 }
 
@@ -397,9 +431,36 @@ body {
     box-shadow: 0 4px 15px rgba(101, 79, 111, 0.3);
 }
 
-.btn-exit:hover {
+@media (hover: hover) {
+    .btn-exit:hover {
+        background: linear-gradient(135deg, #544261 0%, #654F6F 100%);
+        box-shadow: 0 6px 20px rgba(101, 79, 111, 0.5);
+    }
+}
+.btn-exit:active {
     background: linear-gradient(135deg, #544261 0%, #654F6F 100%);
-    box-shadow: 0 6px 20px rgba(101, 79, 111, 0.5);
+}
+
+/* Quiz Header Buttons (advanced/hardcore) */
+.quiz-header-buttons {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.quiz-header-form {
+    display: inline;
+}
+
+.btn-quiz-header {
+    width: 120px;
+    padding: 0.5rem 0.75rem;
+    border: none;
+    font-size: 0.9rem;
+    box-sizing: border-box;
+}
+
+.btn-quiz-header.btn-secondary {
+    margin-left: 0;
 }
 
 /* Quiz Page */
@@ -509,12 +570,19 @@ body {
     line-height: 1.2;        /* Keeps lines tight so they don't look like separate options */
 }
 
-.option-btn:hover {
+@media (hover: hover) {
+    .option-btn:hover {
+        background: linear-gradient(135deg, #EDD382 0%, #FC9E4F 100%);
+        color: white;
+        border-color: #FC9E4F;
+        transform: translateY(-3px);
+        box-shadow: 0 12px 30px rgba(252, 158, 79, 0.4), 0 0 20px rgba(252, 158, 79, 0.2);
+    }
+}
+.option-btn:active {
     background: linear-gradient(135deg, #EDD382 0%, #FC9E4F 100%);
     color: white;
     border-color: #FC9E4F;
-    transform: translateY(-3px);
-    box-shadow: 0 12px 30px rgba(252, 158, 79, 0.4), 0 0 20px rgba(252, 158, 79, 0.2);
 }
 
 .option-btn:active {
@@ -835,9 +903,14 @@ body {
     box-shadow: 0 4px 15px rgba(252, 158, 79, 0.3);
 }
 
-.btn-try-again:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 10px 30px rgba(252, 158, 79, 0.5), 0 0 20px rgba(252, 158, 79, 0.3);
+@media (hover: hover) {
+    .btn-try-again:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 10px 30px rgba(252, 158, 79, 0.5), 0 0 20px rgba(252, 158, 79, 0.3);
+        background: linear-gradient(135deg, #654F6F 0%, #FC9E4F 100%);
+    }
+}
+.btn-try-again:active {
     background: linear-gradient(135deg, #654F6F 0%, #FC9E4F 100%);
 }
 
@@ -915,12 +988,19 @@ body {
     transition: all 0.3s ease;
 }
 
-.btn-feedback:hover {
+@media (hover: hover) {
+    .btn-feedback:hover {
+        background: linear-gradient(135deg, #EDD382 0%, #FC9E4F 100%);
+        color: white;
+        border-color: #FC9E4F;
+        transform: translateY(-2px);
+        box-shadow: 0 8px 20px rgba(252, 158, 79, 0.3);
+    }
+}
+.btn-feedback:active {
     background: linear-gradient(135deg, #EDD382 0%, #FC9E4F 100%);
     color: white;
     border-color: #FC9E4F;
-    transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(252, 158, 79, 0.3);
 }
 
 /* Footer */
@@ -1022,22 +1102,51 @@ body {
     }
 
     .magnitude-slider {
-        max-width: 220px;
+        max-width: 100%;
+    }
+
+    .magnitude-slider::-webkit-slider-thumb {
+        width: 32px;
+        height: 32px;
+    }
+
+    .magnitude-slider::-moz-range-thumb {
+        width: 32px;
+        height: 32px;
+    }
+
+    .magnitude-slider {
+        height: 12px;
+    }
+
+    .magnitude-slider::-moz-range-track {
+        height: 12px;
+    }
+
+    .hero-logo {
+        width: 80px;
+        height: 80px;
+        margin-bottom: 15px;
+    }
+
+    .description {
+        margin-bottom: 20px;
     }
 
     .number-display {
         font-size: 3.5rem;
     }
-    
+
     .options-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .info {
         flex-direction: column;
-        gap: 20px;
+        gap: 15px;
+        margin-top: 20px;
     }
-    
+
     .hero, .results-container, .quiz-page {
         padding: 40px 25px;
     }
@@ -1048,8 +1157,95 @@ body {
     
     .quiz-header {
         font-size: 0.9rem;
+        flex-direction: column;
+        align-items: stretch;
+        text-align: center;
+        gap: 8px;
     }
-    
+
+    .quiz-header .progress-info,
+    .quiz-header .score-display {
+        text-align: center;
+    }
+
+    .quiz-header-buttons {
+        justify-content: center;
+    }
+
+    .btn-quiz-header {
+        width: auto;
+        min-width: 100px;
+        flex: 1;
+        max-width: 140px;
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .btn-exit {
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .quiz-page .question-container {
+        margin-bottom: 25px;
+    }
+
+    .quiz-page .question-label {
+        font-size: 1.2rem;
+        margin-bottom: 15px;
+    }
+
+    .quiz-page .progress-bar {
+        margin-bottom: 20px;
+    }
+
+    /* Results page compaction */
+    .results-container {
+        padding: 30px 20px;
+    }
+
+    .results-logo {
+        width: 70px;
+        height: 70px;
+        margin-bottom: 15px;
+    }
+
+    .results-title {
+        font-size: 1.8rem;
+        margin-bottom: 25px;
+    }
+
+    .score-card {
+        padding: 25px;
+        margin-bottom: 20px;
+    }
+
+    .final-score {
+        font-size: 2.8rem;
+    }
+
+    .percentage {
+        font-size: 2.2rem;
+    }
+
+    .performance-message {
+        margin: 20px 0;
+    }
+
+    .performance-message p {
+        font-size: 1.1rem;
+        padding: 15px;
+    }
+
+    .results-actions {
+        margin-top: 25px;
+        gap: 12px;
+    }
+
     .toast {
         right: 10px;
         left: 10px;
@@ -1066,7 +1262,7 @@ body {
     }
     
     .answer-input {
-        font-size: 1.2rem;
+        font-size: max(1.2rem, 16px);
         padding: 15px;
     }
     
@@ -1074,9 +1270,10 @@ body {
         font-size: 1.1rem;
     }
 
-    /* Easy mode mobile: fit progress bar + question + all 4 options without scrolling */
-    body:has(.quiz-easy-page) {
+    /* Start content from top on mobile instead of vertical centering */
+    body {
         align-items: flex-start;
+        padding-top: 10px;
     }
 
     .quiz-easy-page {
@@ -1119,18 +1316,69 @@ body {
 }
 
 @media (max-width: 768px) and (orientation: portrait) {
+    .hero {
+        padding: 30px 20px;
+    }
+
+    .subtitle {
+        font-size: 1.3rem;
+        margin-bottom: 10px;
+    }
+
     .mode-selection {
         display: flex;
         flex-direction: column;
         align-items: center;
-        gap: 30px;
+        gap: 6px;
+        margin: 10px 0 6px;
     }
 
     .mode-card {
         width: 100%;
-        max-width: 360px;
-        padding: 50px 30px;
-        min-height: 260px;
+        max-width: none;
+        padding: 20px 20px;
+        min-height: auto;
+    }
+
+    .mode-title {
+        font-size: 1.3rem;
+        margin-bottom: 10px;
+    }
+
+    .mode-description {
+        font-size: 0.85rem;
+        margin-bottom: 12px;
+        min-height: auto;
+        line-height: 1.4;
+    }
+
+    .magnitude-dial-section {
+        margin-bottom: 20px;
+    }
+
+    .feedback-section {
+        margin-top: 20px;
+    }
+
+    .page-footer {
+        margin-top: 20px;
+        padding-top: 15px;
+    }
+
+    /* Language selection compaction */
+    .language-flag {
+        font-size: 2.5rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .language-flag-icon {
+        width: 2.5rem;
+        height: 2.5rem;
+    }
+
+    .language-native-name {
+        font-size: 0.9rem;
+        margin: 0.15rem 0 0.5rem 0;
     }
 }
 
@@ -1252,8 +1500,13 @@ body {
     white-space: nowrap;
 }
 
-.cookie-accept-btn:hover {
-    transform: translateY(-2px);
+@media (hover: hover) {
+    .cookie-accept-btn:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 20px rgba(252, 158, 79, 0.4);
+    }
+}
+.cookie-accept-btn:active {
     box-shadow: 0 6px 20px rgba(252, 158, 79, 0.4);
 }
 
@@ -1318,9 +1571,14 @@ html {
     box-shadow: 0 4px 15px rgba(101, 79, 111, 0.3);
 }
 
-.btn-back:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(101, 79, 111, 0.4);
+@media (hover: hover) {
+    .btn-back:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 8px 25px rgba(101, 79, 111, 0.4);
+        background: linear-gradient(135deg, #FC9E4F 0%, #EDD382 100%);
+    }
+}
+.btn-back:active {
     background: linear-gradient(135deg, #FC9E4F 0%, #EDD382 100%);
 }
 
@@ -1388,10 +1646,16 @@ html {
     border-radius: 6px;
 }
 
-.learn-toc a:hover {
+@media (hover: hover) {
+    .learn-toc a:hover {
+        color: #FC9E4F;
+        background: rgba(255, 255, 255, 0.7);
+        transform: translateX(5px);
+    }
+}
+.learn-toc a:active {
     color: #FC9E4F;
     background: rgba(255, 255, 255, 0.7);
-    transform: translateX(5px);
 }
 
 .learn-section {
@@ -1404,9 +1668,11 @@ html {
     transition: all 0.3s ease;
 }
 
-.learn-section:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 8px 25px rgba(252, 158, 79, 0.2);
+@media (hover: hover) {
+    .learn-section:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(252, 158, 79, 0.2);
+    }
 }
 
 .learn-section h2 {
@@ -1458,9 +1724,11 @@ html {
     transition: all 0.3s ease;
 }
 
-.learn-check:hover {
-    border-color: #FC9E4F;
-    box-shadow: 0 4px 15px rgba(252, 158, 79, 0.15);
+@media (hover: hover) {
+    .learn-check:hover {
+        border-color: #FC9E4F;
+        box-shadow: 0 4px 15px rgba(252, 158, 79, 0.15);
+    }
 }
 
 .learn-check summary {
@@ -1533,9 +1801,14 @@ html {
     margin: 0 auto;
 }
 
-.learn-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 40px rgba(101, 79, 111, 0.5);
+@media (hover: hover) {
+    .learn-card:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 15px 40px rgba(101, 79, 111, 0.5);
+        background: linear-gradient(135deg, #FC9E4F 0%, #EDD382 100%);
+    }
+}
+.learn-card:active {
     background: linear-gradient(135deg, #FC9E4F 0%, #EDD382 100%);
 }
 
@@ -1563,10 +1836,12 @@ html {
     opacity: 0.7;
 }
 
-.learn-card.learn-unavailable:hover {
-    transform: none;
-    background: linear-gradient(135deg, #9a9a9a 0%, #b8b8b8 100%);
-    box-shadow: 0 8px 25px rgba(100, 100, 100, 0.2);
+@media (hover: hover) {
+    .learn-card.learn-unavailable:hover {
+        transform: none;
+        background: linear-gradient(135deg, #9a9a9a 0%, #b8b8b8 100%);
+        box-shadow: 0 8px 25px rgba(100, 100, 100, 0.2);
+    }
 }
 
 .results-learn-unavailable {
@@ -1744,9 +2019,11 @@ html {
     box-shadow: 0 4px 15px rgba(101, 79, 111, 0.3);
 }
 
-.btn-back:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(101, 79, 111, 0.4);
+@media (hover: hover) {
+    .btn-back:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 20px rgba(101, 79, 111, 0.4);
+    }
 }
 
 .learn-hero {
@@ -1823,11 +2100,13 @@ html {
     font-size: 0.95rem;
 }
 
-.learn-toc a:hover {
-    background: white;
-    transform: translateX(5px);
-    box-shadow: 0 2px 10px rgba(2, 1, 34, 0.1);
-    color: #FC9E4F;
+@media (hover: hover) {
+    .learn-toc a:hover {
+        background: white;
+        transform: translateX(5px);
+        box-shadow: 0 2px 10px rgba(2, 1, 34, 0.1);
+        color: #FC9E4F;
+    }
 }
 
 .learn-section {
@@ -1884,9 +2163,11 @@ html {
     transition: all 0.3s ease;
 }
 
-.learn-check:hover {
-    background: linear-gradient(135deg, #F2F3AE 0%, #EDD382 100%);
-    box-shadow: 0 4px 15px rgba(252, 158, 79, 0.2);
+@media (hover: hover) {
+    .learn-check:hover {
+        background: linear-gradient(135deg, #F2F3AE 0%, #EDD382 100%);
+        box-shadow: 0 4px 15px rgba(252, 158, 79, 0.2);
+    }
 }
 
 .learn-check summary {
@@ -1955,9 +2236,11 @@ html {
     text-align: center;
 }
 
-.learn-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 40px rgba(101, 79, 111, 0.5);
+@media (hover: hover) {
+    .learn-card:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 15px 40px rgba(101, 79, 111, 0.5);
+    }
 }
 
 .learn-icon {

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,8 +28,8 @@
 <div class="landing-page">
     <div class="hero">
         <!-- Back to language selection -->
-        <div style="text-align: left; margin-bottom: 1rem;">
-            <a href="{{ url_for('index') }}" class="btn btn-secondary" style="display: inline-block; padding: 0.5rem 1rem;">
+        <div class="back-nav">
+            <a href="{{ url_for('index') }}" class="btn btn-secondary btn-back-nav">
                 ← {{ get_text('language_selection_back') }}
             </a>
         </div>
@@ -41,7 +41,7 @@
             {{ get_text('home_hero_description') }}
         </p>
         
-        <div class="mode-selection">
+        <div class="mode-selection" id="mode-selection">
             <div class="mode-card">
                 <h3 class="mode-title">{{ get_text('mode_easy') }}</h3>
                 <p class="mode-description">{{ get_text('mode_easy_desc') }}</p>
@@ -155,4 +155,10 @@
         </footer>
     </div>
 </div>
+<script>
+if (window.innerWidth <= 768) {
+    var el = document.getElementById('mode-selection');
+    if (el) el.scrollIntoView({ behavior: 'instant', block: 'start' });
+}
+</script>
 {% endblock %}

--- a/templates/quiz_advanced.html
+++ b/templates/quiz_advanced.html
@@ -18,12 +18,12 @@
         <div class="score-display">
             {{ get_text('quiz_score') }}: {{ score }} / {{ total }}
         </div>
-        <div style="display: flex; gap: 0.5rem;">
-            <form action="{{ url_for('results', lang_code=lang_code) }}" method="GET" style="display: inline;">
-                <button type="submit" class="btn btn-exit" style="width: 120px !important; padding: 0.5rem 0.75rem !important; border: none !important; font-size: 0.9rem; box-sizing: border-box;">{{ get_text('quiz_exit') }}</button>
+        <div class="quiz-header-buttons">
+            <form action="{{ url_for('results', lang_code=lang_code) }}" method="GET" class="quiz-header-form">
+                <button type="submit" class="btn btn-exit btn-quiz-header">{{ get_text('quiz_exit') }}</button>
             </form>
-            <form action="{{ url_for('quiz_advanced', lang_code=lang_code) }}" method="POST" style="display: inline;">
-                <button type="submit" name="give_up" value="1" class="btn btn-secondary" style="width: 120px !important; padding: 0.5rem 0.75rem !important; border: none !important; font-size: 0.9rem; box-sizing: border-box; margin-left: 0 !important;" title="{{ get_text('quiz_skip_tooltip') }}">
+            <form action="{{ url_for('quiz_advanced', lang_code=lang_code) }}" method="POST" class="quiz-header-form">
+                <button type="submit" name="give_up" value="1" class="btn btn-secondary btn-quiz-header" title="{{ get_text('quiz_skip_tooltip') }}">
                     {{ get_text('quiz_skip') }}
                 </button>
             </form>

--- a/templates/quiz_easy.html
+++ b/templates/quiz_easy.html
@@ -45,13 +45,4 @@
         </div>
     </form>
 </div>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    if (window.innerWidth <= 768) {
-        var el = document.getElementById('easy-progress-bar');
-        if (el) el.scrollIntoView({ behavior: 'instant', block: 'start' });
-    }
-});
-</script>
 {% endblock %}

--- a/templates/quiz_hardcore.html
+++ b/templates/quiz_hardcore.html
@@ -18,12 +18,12 @@
         <div class="score-display">
             {{ get_text('quiz_score') }}: {{ score }} / {{ total }}
         </div>
-        <div style="display: flex; gap: 0.5rem;">
-            <form action="{{ url_for('results', lang_code=lang_code) }}" method="GET" style="display: inline;">
-                <button type="submit" class="btn btn-exit" style="width: 120px !important; padding: 0.5rem 0.75rem !important; border: none !important; font-size: 0.9rem; box-sizing: border-box;">{{ get_text('quiz_exit') }}</button>
+        <div class="quiz-header-buttons">
+            <form action="{{ url_for('results', lang_code=lang_code) }}" method="GET" class="quiz-header-form">
+                <button type="submit" class="btn btn-exit btn-quiz-header">{{ get_text('quiz_exit') }}</button>
             </form>
-            <form action="{{ url_for('quiz_hardcore', lang_code=lang_code) }}" method="POST" style="display: inline;">
-                <button type="submit" name="give_up" value="1" class="btn btn-secondary" style="width: 120px !important; padding: 0.5rem 0.75rem !important; border: none !important; font-size: 0.9rem; box-sizing: border-box; margin-left: 0 !important;" title="{{ get_text('quiz_skip_tooltip') }}">
+            <form action="{{ url_for('quiz_hardcore', lang_code=lang_code) }}" method="POST" class="quiz-header-form">
+                <button type="submit" name="give_up" value="1" class="btn btn-secondary btn-quiz-header" title="{{ get_text('quiz_skip_tooltip') }}">
                     {{ get_text('quiz_skip') }}
                 </button>
             </form>


### PR DESCRIPTION
- Compact mode selection page in portrait: smaller hero, tighter mode cards (padding, gaps, min-height), full-width magnitude slider with larger touch thumb, auto-scroll to mode cards on load
- Fix quiz headers: replace inline !important styles with CSS classes, stack vertically on mobile with centered layout
- Compact results page: reduced padding, font sizes, and spacing
- Compact language selection: smaller flags and text in portrait
- Touch-friendly hover/active: wrap all transform-based :hover effects in @media (hover: hover) to prevent sticky states on touch devices, add :active pseudo-classes for tap feedback
- General: body starts from top on mobile, 44px min touch targets, tap-highlight removal, iOS zoom prevention on text inputs